### PR TITLE
Update CITATION.cff with new organization name

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     given-names: "James Richard"
     orcid: "https://orcid.org/0000-0002-1987-9268"
     affiliation: "McGill University"
-title: "decarsg/pykoop"
+title: "decargroup/pykoop"
 version: v1.0.5
 doi: 10.5281/zenodo.5576490
 date-released: 2022-09-02
-url: "https://github.com/decarsg/pykoop"
+url: "https://github.com/decargroup/pykoop"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
     orcid: "https://orcid.org/0000-0002-1987-9268"
     affiliation: "McGill University"
 title: "decargroup/pykoop"
-version: v1.0.5
+version: v1.1.0
 doi: 10.5281/zenodo.5576490
 date-released: 2022-09-02
 url: "https://github.com/decargroup/pykoop"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,4 +15,4 @@ Contributed code must
 5. pass existing unit tests and checks.
 
 If you notice a problem or would like to suggest an enhancement, please create
-an [issue](https://github.com/decarsg/pykoop/issues).
+an [issue](https://github.com/decargroup/pykoop/issues).

--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,10 @@ learn a linear model of a given system in the lifted space.
    :alt: Koopman pipeline diagram
 
 To learn more about Koopman operator theory, check out
-`this talk <https://www.youtube.com/watch?v=Lidd_M7gzvA>`_ by
-`Steven Dahdah <https://github.com/sdahdah>`_.
+`this talk <https://www.youtube.com/watch?v=Lidd_M7gzvA>`_
+or
+`this review article <https://arxiv.org/abs/2102.12086>`_.
+
 
 ``pykoop`` places heavy emphasis on modular lifting function construction and
 ``scikit-learn`` compatibility. The library aims to make it easy to

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@
 pykoop
 ======
 
-.. image:: https://github.com/decarsg/pykoop/actions/workflows/test-package.yml/badge.svg
-    :target: https://github.com/decarsg/pykoop/actions/workflows/test-package.yml
+.. image:: https://github.com/decargroup/pykoop/actions/workflows/test-package.yml/badge.svg
+    :target: https://github.com/decargroup/pykoop/actions/workflows/test-package.yml
     :alt: Test package
 .. image:: https://readthedocs.org/projects/pykoop/badge/?version=stable
     :target: https://pykoop.readthedocs.io/en/stable/?badge=stable
@@ -13,14 +13,14 @@ pykoop
     :target: https://doi.org/10.5281/zenodo.5576490
     :alt: DOI
 .. image:: https://mybinder.org/badge_logo.svg
-    :target: https://mybinder.org/v2/gh/decarsg/pykoop/main?labpath=notebooks
+    :target: https://mybinder.org/v2/gh/decargroup/pykoop/main?labpath=notebooks
     :alt: Examples on binder
 
 ``pykoop`` is a Koopman operator identification library written in Python. It
 allows the user to specify Koopman lifting functions and regressors in order to
 learn a linear model of a given system in the lifted space.
 
-.. image:: https://raw.githubusercontent.com/decarsg/pykoop/main/doc/_static/pykoop_diagram.png
+.. image:: https://raw.githubusercontent.com/decargroup/pykoop/main/doc/_static/pykoop_diagram.png
    :alt: Koopman pipeline diagram
 
 To learn more about Koopman operator theory, check out
@@ -82,7 +82,7 @@ mass-spring-damper data. Using ``pykoop``, this can be implemented as:
     kp.plot_predicted_trajectory(eg['X_valid'], plot_input=True)
 
 More examples are available in ``examples/``, in ``notebooks/``, or on
-`binder <https://mybinder.org/v2/gh/decarsg/pykoop/main?labpath=notebooks>`_.
+`binder <https://mybinder.org/v2/gh/decargroup/pykoop/main?labpath=notebooks>`_.
 
 
 Library layout
@@ -199,7 +199,7 @@ Library      Unique features
              - Related to, but not the same as, Koopman operator approximation
 ============ ==================================================================
 
-.. _pykoop: https://github.com/decarsg/pykoop
+.. _pykoop: https://github.com/decargroup/pykoop
 .. _pykoopman: https://github.com/dynamicslab/pykoopman
 .. _PyDMD: https://github.com/mathLab/PyDMD
 .. _PySINDy: https://github.com/dynamicslab/pysindy
@@ -214,9 +214,9 @@ If you use this software in your research, please cite it as below or see
 .. code-block:: bibtex
 
     @software{dahdah_pykoop_2022,
-        title={{decarsg/pykoop}},
+        title={{decargroup/pykoop}},
         doi={10.5281/zenodo.5576490},
-        url={https://github.com/decarsg/pykoop},
+        url={https://github.com/decargroup/pykoop},
         publisher={Zenodo},
         author={Steven Dahdah and James Richard Forbes},
         version = {{v1.0.5}},

--- a/README.rst
+++ b/README.rst
@@ -219,7 +219,7 @@ If you use this software in your research, please cite it as below or see
         url={https://github.com/decargroup/pykoop},
         publisher={Zenodo},
         author={Steven Dahdah and James Richard Forbes},
-        version = {{v1.0.5}},
+        version = {{v1.1.0}},
         year={2022},
     }
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     long_description=readme,
     author='Steven Dahdah',
     author_email='steven.dahdah@mail.mcgill.ca',
-    url='https://github.com/decarsg/pykoop',
+    url='https://github.com/decargroup/pykoop',
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: MIT License',
@@ -19,8 +19,8 @@ setuptools.setup(
     ],
     project_urls={
         'Documentation': 'https://pykoop.readthedocs.io/en/latest',
-        'Source': 'https://github.com/decarsg/pykoop',
-        'Tracker': 'https://github.com/decarsg/pykoop/issues',
+        'Source': 'https://github.com/decargroup/pykoop',
+        'Tracker': 'https://github.com/decargroup/pykoop/issues',
         'PyPI': 'https://pypi.org/project/pykoop/',
         'DOI': 'https://doi.org/10.5281/zenodo.5576490',
     },

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r') as f:
 
 setuptools.setup(
     name='pykoop',
-    version='1.0.5',
+    version='1.1.0',
     description='Koopman operator identification library in Python',
     long_description=readme,
     author='Steven Dahdah',


### PR DESCRIPTION
Resolves #101 

# Proposed Changes

- Rename `decarsg` to `decargroup`.
- Bump version from `v1.0.5` to `v1.1.0`.

# Checklist

- [x] Write unit tests
- [x] Add new estimators to existing `scikit-learn` compatibility tests
- [x] Write examples in docstrings
- [x] Update Sphinx documentation
