### PR TITLE
Lower required Python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ setuptools.setup(
         'DOI': 'https://doi.org/10.5281/zenodo.5576490',
     },
     packages=setuptools.find_packages(exclude=('tests', 'examples', 'doc')),
-    python_requires='>=3.8',
+    # Officially, Python 3.8 is the lowest supported version, but almost
+    # everything works on Python 3.7.
+    python_requires='>=3.7',
     install_requires=[
         'numpy>=1.21.0',
         'scipy>=1.7.0',


### PR DESCRIPTION
Resolves #113 

# Proposed Changes

- Lower required Python version in `setup.py` to 3.7 to fix Binder compatibility.

# Checklist

- [x] Write unit tests
- [x] Add new estimators to existing `scikit-learn` compatibility tests
- [x] Write examples in docstrings
- [x] Update Sphinx documentation
