### PR TITLE
`score_trajectory()` sometimes returns `inf` instead of error score

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,5 +14,8 @@ Contributed code must
 4. include relevant unit tests, and
 5. pass existing unit tests and checks.
 
+If you are fixing a bug, please include a set of unit tests in your pull
+request that would fail without your changes.
+
 If you notice a problem or would like to suggest an enhancement, please create
 an [issue](https://github.com/decargroup/pykoop/issues).

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -3245,7 +3245,7 @@ def score_trajectory(
     }
     # Scores that do not need inversion
     greater_is_better = ['explained_variance', 'r2']
-    # Return NaN if any of inputs are NaN
+    # Return error score if any of inputs are NaN or inf
     if not (np.all(np.isfinite(X_predicted))
             and np.all(np.isfinite(X_expected))):
         if error_score == 'raise':
@@ -3285,6 +3285,16 @@ def score_trajectory(
         sample_weight=weights,
         multioutput='uniform_average',
     )
+    # Return error score if score is not finite
+    if not np.isfinite(score):
+        if error_score == 'raise':
+            raise ValueError(
+                'Prediction diverged or error occured while scoring.')
+        else:
+            warnings.warn(
+                'Prediction diverged or error occured while scoring, '
+                'returning error score.', sklearn.exceptions.FitFailedWarning)
+            return error_score
     # Invert losses
     if regression_metric not in greater_is_better:
         score *= -1

--- a/tests/test_koopman_pipeline.py
+++ b/tests/test_koopman_pipeline.py
@@ -530,6 +530,36 @@ class TestKoopmanPipelineScore:
                 False,
                 None,
             ),
+            (
+                np.array([
+                    [1e-2, 1e-3],
+                ]).T,
+                np.array([
+                    [1e150, 1e250],
+                ]).T,
+                None,
+                1,
+                'neg_mean_squared_error',
+                -100,
+                1,
+                False,
+                -100,
+            ),
+            (
+                np.array([
+                    [1e-2, 1e-3],
+                ]).T,
+                np.array([
+                    [1e150, 1e250],
+                ]).T,
+                None,
+                1,
+                'neg_mean_squared_error',
+                'raise',
+                1,
+                False,
+                None,
+            ),
         ],
     )
     def test_score_trajectory(


### PR DESCRIPTION
Resolves #126 

# Proposed Changes

- Add check to output of `score_trajectory()` in case the score becomes nonfinite during calculation.

# Checklist

- [ ] Write unit tests
- [ ] Add new estimators to existing `scikit-learn` compatibility tests
- [ ] Write examples in docstrings
- [ ] Update Sphinx documentation
- [ ] Bump version number and date in `setup.py`, `CITATION.cff`, and
      `README.rst`
