### PR TITLE
Allow creation of a `KoopmanRegressor` object from a Koopman matrix

### DIFF
--- a/doc/pykoop.rst
+++ b/doc/pykoop.rst
@@ -153,6 +153,10 @@ The following class and function implementations are located in
 ``pykoop.regressors``, but have been imported into the ``pykoop`` namespace for
 convenience.
 
+The :class:`pykoop.DataRegressor` regressor is a dummy regressor if you want to
+force the Koopman matrix to take on a specific value (maybe you know what it
+should be, or you got it from another library).
+
 .. autosummary::
    :toctree: _autosummary/
 
@@ -160,6 +164,7 @@ convenience.
    pykoop.Dmdc
    pykoop.Edmd
    pykoop.EdmdMeta
+   pykoop.DataRegressor
 
 
 Kernel approximation methods
@@ -262,6 +267,7 @@ The following class and function implementations are located in
    :toctree: _autosummary/
 
    pykoop.dynamic_models.DiscreteVanDerPol
+   pykoop.dynamic_models.DuffingOscillator
    pykoop.dynamic_models.MassSpringDamper
    pykoop.dynamic_models.Pendulum
 

--- a/pykoop/__init__.py
+++ b/pykoop/__init__.py
@@ -39,7 +39,7 @@ from .lifting_functions import (
     KernelApproxLiftingFn,
     SkLearnLiftingFn,
 )
-from .regressors import Dmd, Dmdc, Edmd, EdmdMeta
+from .regressors import Dmd, Dmdc, Edmd, EdmdMeta, DataRegressor
 from .tsvd import Tsvd
 from .util import (
     AnglePreprocessor,

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -1193,8 +1193,11 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
             X = sklearn.utils.validation.check_array(
                 X, **self._check_array_params)
         else:
-            X, y = sklearn.utils.validation.check_X_y(X, y,
-                                                      **self._check_X_y_params)
+            X, y = sklearn.utils.validation.check_X_y(
+                X,
+                y,
+                **self._check_X_y_params,
+            )
         # Validate constructor parameters
         self._validate_parameters()
         # Compute fit attributes

--- a/pykoop/regressors.py
+++ b/pykoop/regressors.py
@@ -449,6 +449,23 @@ class DataRegressor(koopman_pipeline.KoopmanRegressor):
         Array of input feature name strings.
     coef_ : np.ndarray
         Fit coefficient matrix.
+
+    Examples
+    --------
+    Create a Koopman pipeline with the Koopman matrix forced to be::
+
+        0.0 -0.5
+        1.0 -0.5
+        0.0  1.0
+
+    You may want to do this because you have a Koopman matrix from another
+    library and you want to use ``pykoop`` to evaluate its performance.
+
+    >>> kp = pykoop.KoopmanPipeline(regressor=pykoop.DataRegressor(
+    ...     coef=np.array([[0, 1, 0], [-0.5, -0.5, 1]]).T)
+    ... )
+    >>> kp.fit(X_msd, n_inputs=1, episode_feature=True)
+    KoopmanPipeline(regressor=DataRegressor(coef=array(...
     """
 
     def __init__(self, coef: np.ndarray = None) -> None:

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -210,6 +210,7 @@ class TestSkLearn:
         pykoop.EdmdMeta(regressor=sklearn.linear_model.Ridge(alpha=1)),
         pykoop.Dmdc(),
         pykoop.Dmd(),
+        pykoop.DataRegressor(),
     ])
     def test_compatible_estimator(self, estimator, check):
         """Test ``scikit-learn`` compatibility of estimators."""
@@ -224,11 +225,14 @@ class TestExceptions:
         [4, 3, 2, 1],
     ])
 
-    @pytest.mark.parametrize('estimator', [
-        pykoop.Edmd(alpha=-1),
-        pykoop.Dmdc(mode_type='blah'),
-        pykoop.Dmd(mode_type='blah'),
-    ])
+    @pytest.mark.parametrize(
+        'estimator',
+        [
+            pykoop.Edmd(alpha=-1),
+            pykoop.Dmdc(mode_type='blah'),
+            pykoop.Dmd(mode_type='blah'),
+            pykoop.DataRegressor(coef=np.eye(2)),  # Wrong dimensions for data
+        ])
     def test_invalid_params(self, estimator):
         """Test a selection of invalid estimator parameter."""
         with pytest.raises(ValueError):

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -124,6 +124,51 @@ class TestRegressorsExact:
         )
 
 
+class TestDataRegressorExact:
+    """Test :class:`DataRegressor` with exact solutions."""
+
+    def test_fit(self, request):
+        """Test fit accuracy by comparing Koopman matrix."""
+        # Get fixture from name
+        msd = request.getfixturevalue('mass_spring_damper_sine_input')
+        regressor = pykoop.DataRegressor(coef=msd['U_valid'].T)
+        # Fit regressor
+        regressor.fit(
+            msd['X_train'],
+            msd['Xp_train'],
+            n_inputs=msd['n_inputs'],
+            episode_feature=msd['episode_feature'],
+        )
+        # Test value of Koopman operator
+        np.testing.assert_allclose(
+            regressor.coef_.T,
+            msd['U_valid'],
+            atol=1e-5,
+            rtol=0,
+        )
+
+    def test_predict(self, request):
+        """Test fit accuracy by comparing prediction."""
+        # Get fixture from name
+        msd = request.getfixturevalue('mass_spring_damper_sine_input')
+        regressor = pykoop.DataRegressor(coef=msd['U_valid'].T)
+        # Fit regressor
+        regressor.fit(
+            msd['X_train'],
+            msd['Xp_train'],
+            n_inputs=msd['n_inputs'],
+            episode_feature=msd['episode_feature'],
+        )
+        # Test prediction
+        prediction = regressor.predict(msd['X_valid'])
+        np.testing.assert_allclose(
+            prediction,
+            msd['Xp_valid'],
+            atol=1e-3,
+            rtol=0,
+        )
+
+
 @pytest.mark.parametrize(
     'regressor, mass_spring_damper',
     [


### PR DESCRIPTION
Resolves #125 

# Proposed Changes

- Add `DataRegressor`, which accepts a Koopman matrix in the form of a NumPy array as input.

# Checklist

- [ ] Write unit tests
- [ ] Add new estimators to existing `scikit-learn` compatibility tests
- [ ] Write examples in docstrings
- [ ] Update Sphinx documentation
- [ ] Bump version number and date in `setup.py`, `CITATION.cff`, and
      `README.rst`
