### PR TITLE
`score_trajectory` can return score worse than error score

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 DECAR Systems Group
+Copyright (c) 2022 DECAR
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -2821,7 +2821,9 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
             an error has occured in estimator fitting. If set to ``'raise'``, a
             :class:`ValueError` is raised. If a numerical value is given, a
             :class:`sklearn.exceptions.FitFailedWarning` warning is raised and
-            the specified score is returned.
+            the specified score is returned. The error score defines the worst
+            possible score. If a score is finite but lower than the error
+            score, the error score will be returned instead.
 
         multistep : bool
             If true, predict using :func:`predict_trajectory`. Otherwise,
@@ -3204,7 +3206,9 @@ def score_trajectory(
         error has occured in estimator fitting. If set to ``'raise'``, a
         :class:`ValueError` is raised. If a numerical value is given, a
         :class:`sklearn.exceptions.FitFailedWarning` warning is raised and the
-        specified score is returned.
+        specified score is returned. The error score defines the worst possible
+        score. If a score is finite but lower than the error score, the error
+        score will be returned instead.
 
     min_samples : int
         Number of samples in initial condition.
@@ -3300,6 +3304,10 @@ def score_trajectory(
         score *= -1
     # If score is worse than error score, return that.
     if np.isfinite(error_score) and (score < error_score):
+        warnings.warn(
+            f'Score `score={score}` is finite, but is lower than error '
+            f'score `error_score={error_score}`. Returning error score.',
+            sklearn.exceptions.FitFailedWarning)
         return error_score
     return score
 

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -3298,6 +3298,9 @@ def score_trajectory(
     # Invert losses
     if regression_metric not in greater_is_better:
         score *= -1
+    # If score is worse than error score, return that.
+    if np.isfinite(error_score) and (score < error_score):
+        return error_score
     return score
 
 

--- a/tests/test_koopman_pipeline.py
+++ b/tests/test_koopman_pipeline.py
@@ -560,6 +560,22 @@ class TestKoopmanPipelineScore:
                 False,
                 None,
             ),
+            # Finite score worse than error score should return error score.
+            (
+                np.array([
+                    [1e-2, 1e-3],
+                ]).T,
+                np.array([
+                    [1e5, 1e6],
+                ]).T,
+                None,
+                1,
+                'neg_mean_squared_error',
+                -100,
+                1,
+                False,
+                -100,
+            ),
         ],
     )
     def test_score_trajectory(


### PR DESCRIPTION
Resolves #130 and #131 

# Proposed Changes

- Ensure that when `error_score` is a finite number, it is the lowest possible score. If a finite score worse than the error score would be returned, the error score is returned instead. This is to ensure compatibility with hyperparameter optimizers.
- Change name in `LICENSE` file.

# Checklist

- [x] Write unit tests
- [x] Add new estimators to existing `scikit-learn` compatibility tests
- [x] Write examples in docstrings
- [x] Update Sphinx documentation
- [x] Bump version number and date in `setup.py`, `CITATION.cff`, and
      `README.rst`
