### PR TITLE
Update pytest test pattern for examples

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,7 +6,7 @@ markers =
     mosek: marks tests that need a MOSEK license (deselect with `-m "not mosek"`)
 python_files =
     test_*.py
-    example_*.py
+    *_example_*.py
 python_functions =
     test*
     example*


### PR DESCRIPTION
Resolves #137 

# Proposed Changes

- Change pytest pattern for examples to `*_example_*.py`

# Checklist

- [x] Write unit tests
- [x] Add new estimators to existing `scikit-learn` compatibility tests
- [x] Write examples in docstrings
- [x] Update Sphinx documentation
- [x] Bump version number and date in `setup.py`, `CITATION.cff`, and
      `README.rst`
