### PR TITLE
Update MyPy optional typing

### DIFF
--- a/doc/references.rst
+++ b/doc/references.rst
@@ -16,6 +16,9 @@ References
 .. [BFV20] Daniel Bruder, Xun Fu, and Ram Vasudevan. "Advantages of bilinear
    Koopman realizations for the modeling and control of systems with unknown
    dynamics." arXiv:2010.09961v3 [cs.RO] (2020).
+.. [PD20] Shaowu Pan and Karthik Duraisamy. "On the structure of time-delay
+   embedding in linear models of non-linear dynamical systems." Chaos, vol. 30,
+   no. 7, 2020. https://doi.org/10.1063/5.0010886
 .. [MAM22] Giorgos Mamakoukas, Ian Abraham, and Todd D. Murphey. "Learning
    Stable Models for Prediction and Control." arXiv:2005.04291v2 [cs.RO]
    (2022). https://arxiv.org/abs/2005.04291v2

--- a/pykoop/kernel_approximation.py
+++ b/pykoop/kernel_approximation.py
@@ -2,7 +2,7 @@
 
 import abc
 import logging
-from typing import Dict, List, Tuple, Union, Any
+from typing import Dict, List, Tuple, Union, Any, Optional
 
 import numpy as np
 import scipy.stats
@@ -38,7 +38,7 @@ class KernelApproximation(
     def fit(
         self,
         X: np.ndarray,
-        y: np.ndarray = None,
+        y: Optional[np.ndarray] = None,
     ) -> 'KernelApproximation':
         """Fit kernel approximation.
 
@@ -46,7 +46,7 @@ class KernelApproximation(
         ----------
         X : np.ndarray
             Data matrix.
-        y : np.ndarray
+        y : Optional[np.ndarray]
             Ignored.
 
         Returns
@@ -134,7 +134,7 @@ class RandomFourierKernelApprox(KernelApproximation):
         n_components: int = 100,
         shape: float = 1,
         method: str = 'weight_offset',
-        random_state: Union[int, np.random.RandomState] = None,
+        random_state: Union[int, np.random.RandomState, None] = None,
     ) -> None:
         """Instantiate :class:`RandomFourierKernelApprox`.
 
@@ -176,7 +176,7 @@ class RandomFourierKernelApprox(KernelApproximation):
             ``sin(weight.T @ x)``, meaning the number of features generated is
             ``2 * n_components``.
 
-        random_state : Union[int, np.random.RandomState]
+        random_state : Union[int, np.random.RandomState, None]
             Random seed.
         """
         self.kernel_or_ift = kernel_or_ift
@@ -188,7 +188,7 @@ class RandomFourierKernelApprox(KernelApproximation):
     def fit(
         self,
         X: np.ndarray,
-        y: np.ndarray = None,
+        y: Optional[np.ndarray] = None,
     ) -> 'RandomFourierKernelApprox':
         """Fit kernel approximation.
 
@@ -196,7 +196,7 @@ class RandomFourierKernelApprox(KernelApproximation):
         ----------
         X : np.ndarray
             Data matrix.
-        y : np.ndarray
+        y : Optional[np.ndarray]
             Ignored.
 
         Returns
@@ -328,8 +328,8 @@ class RandomBinningKernelApprox(KernelApproximation):
         kernel_or_ddot: Union[str, scipy.stats.rv_continuous] = 'laplacian',
         n_components: int = 100,
         shape: float = 1,
-        encoder_kw: Dict[str, Any] = None,
-        random_state: Union[int, np.random.RandomState] = None,
+        encoder_kw: Optional[Dict[str, Any]] = None,
+        random_state: Union[int, np.random.RandomState, None] = None,
     ) -> None:
         r"""Instantiate :class:`RandomBinningKernelApprox`.
 
@@ -360,12 +360,12 @@ class RandomBinningKernelApprox(KernelApproximation):
             This can lead to a mysterious factor of ``sqrt(2)`` in other
             kernels. Default is ``1``.
 
-        encoder_kw : Dict[str, Any]
+        encoder_kw : Optional[Dict[str, Any]]
             Extra keyword arguments for internal
             :class:`sklearn.preprocessing.OneHotEncoder`. For experimental use
             only. The wrong arguments can break everything. Overrides defaults.
 
-        random_state : Union[int, np.random.RandomState]
+        random_state : Union[int, np.random.RandomState, None]
             Random seed.
         """
         self.kernel_or_ddot = kernel_or_ddot
@@ -377,7 +377,7 @@ class RandomBinningKernelApprox(KernelApproximation):
     def fit(
         self,
         X: np.ndarray,
-        y: np.ndarray = None,
+        y: Optional[np.ndarray] = None,
     ) -> 'RandomBinningKernelApprox':
         """Fit kernel approximation.
 
@@ -385,7 +385,7 @@ class RandomBinningKernelApprox(KernelApproximation):
         ----------
         X : np.ndarray
             Data matrix.
-        y : np.ndarray
+        y : Optional[np.ndarray]
             Ignored.
 
         Returns

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -1366,7 +1366,7 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
         decibels: bool = True,
         subplots_kw: Dict[str, Any] = None,
         plot_kw: Dict[str, Any] = None,
-    ) -> Tuple[plt.Figure, np.ndarray]:
+    ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot frequency response of Koopman system.
 
         Parameters
@@ -1388,9 +1388,8 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
 
         Returns
         -------
-        Tuple[plt.Figure, np.ndarray]
-            Matplotlib :class:`plt.Figure` object and two-dimensional array of
-            :class:`plt.Axes` objects.
+        Tuple[plt.Figure, plt.Axes]
+            Matplotlib :class:`plt.Figure` and :class:`plt.Axes` objects.
 
         Raises
         ------
@@ -1431,7 +1430,7 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
         figure_kw: Dict[str, Any] = None,
         subplot_kw: Dict[str, Any] = None,
         plot_kw: Dict[str, Any] = None,
-    ) -> Tuple[plt.Figure, np.ndarray]:
+    ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot eigenvalues of Koopman ``A`` matrix.
 
         Parameters
@@ -1445,9 +1444,8 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
 
         Returns
         -------
-        Tuple[plt.Figure, np.ndarray]
-            Matplotlib :class:`plt.Figure` object and two-dimensional array of
-            :class:`plt.Axes` objects.
+        Tuple[plt.Figure, plt.Axes]
+            Matplotlib :class:`plt.Figure` and :class:`plt.Axes` objects.
         """
         sklearn.utils.validation.check_is_fitted(self)
         # Get Koopman ``A`` matrix
@@ -1485,7 +1483,7 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
         self,
         subplots_kw: Dict[str, Any] = None,
         plot_kw: Dict[str, Any] = None,
-    ) -> Tuple[plt.Figure, np.ndarray]:
+    ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot heatmap of Koopman matrices.
 
         Parameters
@@ -1497,9 +1495,8 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
 
         Returns
         -------
-        Tuple[plt.Figure, np.ndarray]
-            Matplotlib :class:`plt.Figure` object and two-dimensional array of
-            :class:`plt.Axes` objects.
+        Tuple[plt.Figure, plt.Axes]
+            Matplotlib :class:`plt.Figure` and :class:`plt.Axes` objects.
         """
         sklearn.utils.validation.check_is_fitted(self)
         U = self.coef_.T
@@ -1537,7 +1534,7 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
         self,
         subplots_kw: Dict[str, Any] = None,
         plot_kw: Dict[str, Any] = None,
-    ) -> Tuple[plt.Figure, np.ndarray]:
+    ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot singular values of Koopman matrices.
 
         Parameters
@@ -1549,9 +1546,8 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
 
         Returns
         -------
-        Tuple[plt.Figure, np.ndarray]
-            Matplotlib :class:`plt.Figure` object and two-dimensional array of
-            :class:`plt.Axes` objects.
+        Tuple[plt.Figure, plt.Axes]
+            Matplotlib :class:`plt.Figure` and :class:`plt.Axes` objects.
         """
         sklearn.utils.validation.check_is_fitted(self)
         koop_mat = self.coef_.T
@@ -3164,7 +3160,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         decibels: bool = True,
         subplots_kw: Dict[str, Any] = None,
         plot_kw: Dict[str, Any] = None,
-    ) -> Tuple[plt.Figure, np.ndarray]:
+    ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot frequency response of Koopman system.
 
         Parameters
@@ -3186,9 +3182,8 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
 
         Returns
         -------
-        Tuple[plt.Figure, np.ndarray]
-            Matplotlib :class:`plt.Figure` object and two-dimensional array of
-            :class:`plt.Axes` objects.
+        Tuple[plt.Figure, plt.Axes]
+            Matplotlib :class:`plt.Figure` and :class:`plt.Axes` objects.
 
         Raises
         ------
@@ -3214,7 +3209,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         figure_kw: Dict[str, Any] = None,
         subplot_kw: Dict[str, Any] = None,
         plot_kw: Dict[str, Any] = None,
-    ) -> Tuple[plt.Figure, np.ndarray]:
+    ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot eigenvalues of Koopman ``A`` matrix.
 
         Parameters
@@ -3228,9 +3223,8 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
 
         Returns
         -------
-        Tuple[plt.Figure, np.ndarray]
-            Matplotlib :class:`plt.Figure` object and two-dimensional array of
-            :class:`plt.Axes` objects.
+        Tuple[plt.Figure, plt.Axes]
+            Matplotlib :class:`plt.Figure` and :class:`plt.Axes` objects.
         """
         # Ensure fit has been done
         sklearn.utils.validation.check_is_fitted(self, 'regressor_fit_')
@@ -3245,7 +3239,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         self,
         subplots_kw: Dict[str, Any] = None,
         plot_kw: Dict[str, Any] = None,
-    ) -> Tuple[plt.Figure, np.ndarray]:
+    ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot heatmap of Koopman matrices.
 
         Parameters
@@ -3257,9 +3251,8 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
 
         Returns
         -------
-        Tuple[plt.Figure, np.ndarray]
-            Matplotlib :class:`plt.Figure` object and two-dimensional array of
-            :class:`plt.Axes` objects.
+        Tuple[plt.Figure, plt.Axes]
+            Matplotlib :class:`plt.Figure` and :class:`plt.Axes` objects.
         """
         # Ensure fit has been done
         sklearn.utils.validation.check_is_fitted(self, 'regressor_fit_')
@@ -3269,7 +3262,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         self,
         subplots_kw: Dict[str, Any] = None,
         plot_kw: Dict[str, Any] = None,
-    ) -> Tuple[plt.Figure, np.ndarray]:
+    ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot singular values of Koopman matrices.
 
         Parameters
@@ -3281,9 +3274,8 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
 
         Returns
         -------
-        Tuple[plt.Figure, np.ndarray]
-            Matplotlib :class:`plt.Figure` object and two-dimensional array of
-            :class:`plt.Axes` objects.
+        Tuple[plt.Figure, plt.Axes]
+            Matplotlib :class:`plt.Figure` and :class:`plt.Axes` objects.
         """
         # Ensure fit has been done
         sklearn.utils.validation.check_is_fitted(self, 'regressor_fit_')

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -57,7 +57,7 @@ class KoopmanLiftingFn(
     def fit(
         self,
         X: np.ndarray,
-        y: np.ndarray = None,
+        y: Optional[np.ndarray] = None,
         n_inputs: int = 0,
         episode_feature: bool = False,
     ) -> 'KoopmanLiftingFn':
@@ -67,7 +67,7 @@ class KoopmanLiftingFn(
         ----------
         X : np.ndarray
             Data matrix.
-        y : np.ndarray
+        y : Optional[np.ndarray]
             Ignored.
         n_inputs : int
             Number of input features at the end of ``X``.
@@ -134,7 +134,11 @@ class KoopmanLiftingFn(
         """
         raise NotImplementedError()
 
-    def lift(self, X: np.ndarray, episode_feature: bool = None) -> np.ndarray:
+    def lift(
+        self,
+        X: np.ndarray,
+        episode_feature: Optional[bool] = None,
+    ) -> np.ndarray:
         """Lift state and input.
 
         Potentially more convenient alternative to calling :func:`transform`.
@@ -143,7 +147,7 @@ class KoopmanLiftingFn(
         ----------
         X : np.ndarray
             State and input.
-        episode_feature : bool
+        episode_feature : Optional[bool]
             True if first feature indicates which episode a timestep is from.
             If ``None``, ``self.episode_feature_`` is used.
 
@@ -182,7 +186,7 @@ class KoopmanLiftingFn(
     def retract(
         self,
         X: np.ndarray,
-        episode_feature: bool = None,
+        episode_feature: Optional[bool] = None,
     ) -> np.ndarray:
         """Retract lifted state and input.
 
@@ -193,7 +197,7 @@ class KoopmanLiftingFn(
         ----------
         X : np.ndarray
             Lifted state and input.
-        episode_feature : bool
+        episode_feature : Optional[bool]
             True if first feature indicates which episode a timestep is from.
             If ``None``, ``self.episode_feature_`` is used.
 
@@ -232,7 +236,7 @@ class KoopmanLiftingFn(
     def lift_state(
         self,
         X: np.ndarray,
-        episode_feature: bool = None,
+        episode_feature: Optional[bool] = None,
     ) -> np.ndarray:
         """Lift state only.
 
@@ -243,7 +247,7 @@ class KoopmanLiftingFn(
         ----------
         X : np.ndarray
             State.
-        episode_feature : bool
+        episode_feature : Optional[bool]
             True if first feature indicates which episode a timestep is from.
             If ``None``, ``self.episode_feature_`` is used.
 
@@ -263,7 +267,7 @@ class KoopmanLiftingFn(
     def retract_state(
         self,
         X: np.ndarray,
-        episode_feature: bool = None,
+        episode_feature: Optional[bool] = None,
     ) -> np.ndarray:
         """Retract lifted state only.
 
@@ -274,7 +278,7 @@ class KoopmanLiftingFn(
         ----------
         X : np.ndarray
             Lifted state.
-        episode_feature : bool
+        episode_feature : Optional[bool]
             True if first feature indicates which episode a timestep is from.
             If ``None``, ``self.episode_feature_`` is used.
 
@@ -294,7 +298,7 @@ class KoopmanLiftingFn(
     def lift_input(
         self,
         X: np.ndarray,
-        episode_feature: bool = None,
+        episode_feature: Optional[bool] = None,
     ) -> np.ndarray:
         """Lift input only.
 
@@ -305,7 +309,7 @@ class KoopmanLiftingFn(
         ----------
         X : np.ndarray
             State and input.
-        episode_feature : bool
+        episode_feature : Optional[bool]
             True if first feature indicates which episode a timestep is from.
             If ``None``, ``self.episode_feature_`` is used.
 
@@ -329,7 +333,7 @@ class KoopmanLiftingFn(
     def retract_input(
         self,
         X: np.ndarray,
-        episode_feature: bool = None,
+        episode_feature: Optional[bool] = None,
     ) -> np.ndarray:
         """Retract lifted input only.
 
@@ -341,7 +345,7 @@ class KoopmanLiftingFn(
         ----------
         X : np.ndarray
             Lifted input.
-        episode_feature : bool
+        episode_feature : Optional[bool]
             True if first feature indicates which episode a timestep is from.
             If ``None``, ``self.episode_feature_`` is used.
 
@@ -371,10 +375,10 @@ class KoopmanLiftingFn(
     def plot_lifted_trajectory(
         self,
         X: np.ndarray,
-        episode_feature: bool = None,
-        episode_style: str = None,
-        subplots_kw: Dict[str, Any] = None,
-        plot_kw: Dict[str, Any] = None,
+        episode_feature: Optional[bool] = None,
+        episode_style: Optional[str] = None,
+        subplots_kw: Optional[Dict[str, Any]] = None,
+        plot_kw: Optional[Dict[str, Any]] = None,
     ) -> Tuple[plt.Figure, np.ndarray]:
         """Plot lifted data matrix.
 
@@ -382,16 +386,16 @@ class KoopmanLiftingFn(
         ----------
         X : np.ndarray
             Data matrix.
-        episode_feature : bool
+        episode_feature : Optional[bool]
             True if first feature indicates which episode a timestep is from.
             If ``None``, ``self.episode_feature_`` is used.
-        episode_style : str
+        episode_style : Optional[str]
             If ``'columns'``, each episode is a column (default). If
             ``'overlay'``, states from each episode are plotted overtop of each
             other in different colors.
-        subplots_kw : Dict[str, Any] = None,
+        subplots_kw : Optional[Dict[str, Any]]
             Keyword arguments for :func:`plt.subplots()`.
-        plot_kw : Dict[str, Any] = None,
+        plot_kw : Optional[Dict[str, Any]]
             Keyword arguments for Matplotlib :func:`plt.Axes.plot()`.
 
         Returns
@@ -461,7 +465,7 @@ class KoopmanLiftingFn(
     def _transform_feature_names(
         self,
         feature_names: np.ndarray,
-        format: str = None,
+        format: Optional[str] = None,
     ) -> np.ndarray:
         """Transform feature names.
 
@@ -469,7 +473,7 @@ class KoopmanLiftingFn(
         ----------
         feature_names : np.ndarray
             Feature names.
-        format : str
+        format : Optional[str]
             Feature name formatting method. Possible values are ``'plaintext'``
             (default if ``None``) or ``'latex'``.
 
@@ -482,25 +486,25 @@ class KoopmanLiftingFn(
 
     def get_feature_names_out(
         self,
-        input_features: np.ndarray = None,
+        input_features: Optional[np.ndarray] = None,
         symbols_only: bool = False,
-        format: str = None,
-        episode_feature: bool = None,
+        format: Optional[str] = None,
+        episode_feature: Optional[bool] = None,
     ) -> np.ndarray:
         """Get output feature names.
 
         Parameters
         ----------
-        input_features : np.ndarray
+        input_features : Optional[np.ndarray]
             Array of string input feature names. If provided, they are checked
             against ``feature_names_in_``. If ``None``, ignored.
         symbols_only : bool
             If true, only return symbols (``theta_0``, ``upsilon_0``, etc.).
             Otherwise, returns the full equations (default).
-        format : str
+        format : Optional[str]
             Feature name formatting method. Possible values are ``'plaintext'``
             (default if ``None``) or ``'latex'``.
-        episode_feature : bool
+        episode_feature : Optional[bool]
             True if first feature indicates which episode a timestep is from.
             If ``None``, ``self.episode_feature_`` is used.
 
@@ -540,17 +544,17 @@ class KoopmanLiftingFn(
 
     def get_feature_names_in(
         self,
-        format: str = None,
-        episode_feature: bool = None,
+        format: Optional[str] = None,
+        episode_feature: Optional[bool] = None,
     ) -> np.ndarray:
         """Automatically generate input feature names.
 
         Parameters
         ----------
-        format : str
+        format : Optional[str]
             Feature name formatting method. Possible values are ``'plaintext'``
             (default if ``None``) or ``'latex'``.
-        episode_feature : bool
+        episode_feature : Optional[bool]
             True if first feature indicates which episode a timestep is from.
             If ``None``, ``self.episode_feature_`` is used.
 
@@ -595,8 +599,8 @@ class KoopmanLiftingFn(
     def _generate_feature_names(
         self,
         lifted: bool = False,
-        format: str = None,
-        episode_feature: bool = None,
+        format: Optional[str] = None,
+        episode_feature: Optional[bool] = None,
     ) -> np.ndarray:
         """Generate feature names.
 
@@ -605,10 +609,10 @@ class KoopmanLiftingFn(
         lifted : bool
             If true, return lifted feature names. If false, return unlifted
             feature names (default).
-        format : str
+        format : Optional[str]
             Feature name formatting method. Possible values are ``'plaintext'``
             (default if ``None``) or ``'latex'``.
-        episode_feature : bool
+        episode_feature : Optional[bool]
             True if first feature indicates which episode a timestep is from.
             If ``None``, ``self.episode_feature_`` is used.
 
@@ -694,11 +698,13 @@ class EpisodeIndependentLiftingFn(KoopmanLiftingFn):
         Array of input feature name strings.
     """
 
-    def fit(self,
-            X: np.ndarray,
-            y: np.ndarray = None,
-            n_inputs: int = 0,
-            episode_feature: bool = False) -> 'EpisodeIndependentLiftingFn':
+    def fit(
+        self,
+        X: np.ndarray,
+        y: Optional[np.ndarray] = None,
+        n_inputs: int = 0,
+        episode_feature: bool = False,
+    ) -> 'EpisodeIndependentLiftingFn':
         # noqa: D102
         # Validate constructor parameters
         self._validate_parameters()
@@ -934,7 +940,7 @@ class EpisodeDependentLiftingFn(KoopmanLiftingFn):
 
     def fit(self,
             X: np.ndarray,
-            y: np.ndarray = None,
+            y: Optional[np.ndarray] = None,
             n_inputs: int = 0,
             episode_feature: bool = False) -> 'EpisodeDependentLiftingFn':
         # noqa: D102
@@ -1151,11 +1157,13 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
         'dtype': 'numeric',
     }
 
-    def fit(self,
-            X: np.ndarray,
-            y: np.ndarray = None,
-            n_inputs: int = 0,
-            episode_feature: bool = False) -> 'KoopmanRegressor':
+    def fit(
+        self,
+        X: np.ndarray,
+        y: Optional[np.ndarray] = None,
+        n_inputs: int = 0,
+        episode_feature: bool = False,
+    ) -> 'KoopmanRegressor':
         """Fit the regressor.
 
         If only ``X`` is specified, the regressor will compute its unshifted
@@ -1168,7 +1176,7 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
         X : np.ndarray
             Full data matrix if ``y=None``. Unshifted data matrix if ``y`` is
             specified.
-        y : np.ndarray
+        y : Optional[np.ndarray]
             Optional shifted data matrix. If ``None``, shifted data matrix is
             computed using ``X``.
         n_inputs : int
@@ -1294,7 +1302,7 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
         self,
         t_step: float,
         f_min: float = 0,
-        f_max: float = None,
+        f_max: Optional[float] = None,
         n_points: int = 1000,
         decibels: bool = True,
     ) -> Tuple[np.ndarray, np.ndarray]:
@@ -1306,8 +1314,8 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
             Sampling timestep.
         f_min : float
             Minimum frequency to plot.
-        f_max : float
-            Maximum frequency to plot.
+        f_max : Optional[float]
+            Maximum frequency to plot. If ``None``, uses Nyquist frequency.
         n_points : int
             Number of frequecy points to plot.
         decibels : bool
@@ -1361,11 +1369,11 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
         self,
         t_step: float,
         f_min: float = 0,
-        f_max: float = None,
+        f_max: Optional[float] = None,
         n_points: int = 1000,
         decibels: bool = True,
-        subplots_kw: Dict[str, Any] = None,
-        plot_kw: Dict[str, Any] = None,
+        subplots_kw: Optional[Dict[str, Any]] = None,
+        plot_kw: Optional[Dict[str, Any]] = None,
     ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot frequency response of Koopman system.
 
@@ -1375,15 +1383,15 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
             Sampling timestep.
         f_min : float
             Minimum frequency to plot.
-        f_max : float
-            Maximum frequency to plot.
+        f_max : Optional[float]
+            Maximum frequency to plot. If ``None``, uses Nyquist frequency.
         n_points : int
             Number of frequecy points to plot.
         decibels : bool
             Plot gain in dB (default is true).
-        subplots_kw : Dict[str, Any] = None,
+        subplots_kw : Optional[Dict[str, Any]]
             Keyword arguments for :func:`plt.subplots()`.
-        plot_kw : Dict[str, Any] = None,
+        plot_kw : Optional[Dict[str, Any]]
             Keyword arguments for Matplotlib :func:`plt.Axes.plot()`.
 
         Returns
@@ -1427,19 +1435,19 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
     def plot_eigenvalues(
         self,
         unit_circle: bool = True,
-        figure_kw: Dict[str, Any] = None,
-        subplot_kw: Dict[str, Any] = None,
-        plot_kw: Dict[str, Any] = None,
+        figure_kw: Optional[Dict[str, Any]] = None,
+        subplot_kw: Optional[Dict[str, Any]] = None,
+        plot_kw: Optional[Dict[str, Any]] = None,
     ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot eigenvalues of Koopman ``A`` matrix.
 
         Parameters
         ----------
-        figure_kw : Dict[str, Any] = None,
+        figure_kw : Optional[Dict[str, Any]]
             Keyword arguments for :func:`plt.figure()`.
-        subplot_kw : Dict[str, Any] = None,
+        subplot_kw : Optional[Dict[str, Any]]
             Keyword arguments for :func:`plt.subplot()`.
-        plot_kw : Dict[str, Any] = None,
+        plot_kw : Optional[Dict[str, Any]]
             Keyword arguments for Matplotlib :func:`plt.Axes.plot()`.
 
         Returns
@@ -1481,16 +1489,16 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
 
     def plot_koopman_matrix(
         self,
-        subplots_kw: Dict[str, Any] = None,
-        plot_kw: Dict[str, Any] = None,
+        subplots_kw: Optional[Dict[str, Any]] = None,
+        plot_kw: Optional[Dict[str, Any]] = None,
     ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot heatmap of Koopman matrices.
 
         Parameters
         ----------
-        subplots_kw : Dict[str, Any] = None,
+        subplots_kw : Optional[Dict[str, Any]]
             Keyword arguments for :func:`plt.subplots()`.
-        plot_kw : Dict[str, Any] = None,
+        plot_kw : Optional[Dict[str, Any]]
             Keyword arguments for Matplotlib :func:`plt.Axes.plot()`.
 
         Returns
@@ -1532,16 +1540,16 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
 
     def plot_svd(
         self,
-        subplots_kw: Dict[str, Any] = None,
-        plot_kw: Dict[str, Any] = None,
+        subplots_kw: Optional[Dict[str, Any]] = None,
+        plot_kw: Optional[Dict[str, Any]] = None,
     ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot singular values of Koopman matrices.
 
         Parameters
         ----------
-        subplots_kw : Dict[str, Any] = None,
+        subplots_kw : Optional[Dict[str, Any]]
             Keyword arguments for :func:`plt.subplots()`.
-        plot_kw : Dict[str, Any] = None,
+        plot_kw : Optional[Dict[str, Any]]
             Keyword arguments for Matplotlib :func:`plt.Axes.plot()`.
 
         Returns
@@ -1659,26 +1667,30 @@ class SplitPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
 
     def __init__(
         self,
-        lifting_functions_state: List[Tuple[str, KoopmanLiftingFn]] = None,
-        lifting_functions_input: List[Tuple[str, KoopmanLiftingFn]] = None,
+        lifting_functions_state: Optional[List[Tuple[
+            str, KoopmanLiftingFn]]] = None,
+        lifting_functions_input: Optional[List[Tuple[
+            str, KoopmanLiftingFn]]] = None,
     ) -> None:
         """Instantiate :class:`SplitPipeline`.
 
         Parameters
         ----------
-        lifting_functions_state : List[Tuple[str, KoopmanLiftingFn]]
+        lifting_functions_state : Optional[List[Tuple[str, KoopmanLiftingFn]]]
             Lifting functions to apply to the state features (and their names).
-        lifting_functions_input : List[Tuple[str, KoopmanLiftingFn]]
+        lifting_functions_input : Optional[List[Tuple[str, KoopmanLiftingFn]]]
             Lifting functions to apply to the input features (and their names).
         """
         self.lifting_functions_state = lifting_functions_state
         self.lifting_functions_input = lifting_functions_input
 
-    def fit(self,
-            X: np.ndarray,
-            y: np.ndarray = None,
-            n_inputs: int = 0,
-            episode_feature: bool = False) -> 'SplitPipeline':
+    def fit(
+        self,
+        X: np.ndarray,
+        y: Optional[np.ndarray] = None,
+        n_inputs: int = 0,
+        episode_feature: bool = False,
+    ) -> 'SplitPipeline':
         # noqa: D102
         # Set feature names
         self.feature_names_in_ = _extract_feature_names(X)
@@ -1925,7 +1937,7 @@ class SplitPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
     def _transform_feature_names(
         self,
         feature_names: np.ndarray,
-        format: str = None,
+        format: Optional[str] = None,
     ) -> np.ndarray:
         # noqa: D102
         # Deal with episode feature
@@ -2075,16 +2087,16 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
 
     def __init__(
         self,
-        lifting_functions: List[Tuple[str, KoopmanLiftingFn]] = None,
-        regressor: KoopmanRegressor = None,
+        lifting_functions: Optional[List[Tuple[str, KoopmanLiftingFn]]] = None,
+        regressor: Optional[KoopmanRegressor] = None,
     ) -> None:
         """Instantiate for :class:`KoopmanPipeline`.
 
         Parameters
         ----------
-        lifting_functions : List[Tuple[str, KoopmanLiftingFn]]
+        lifting_functions : Optional[List[Tuple[str, KoopmanLiftingFn]]]
             List of names and lifting function objects.
-        regressor : KoopmanRegressor
+        regressor : Optional[KoopmanRegressor]
             Koopman regressor.
         """
         self.lifting_functions = lifting_functions
@@ -2092,7 +2104,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
 
     def fit(self,
             X: np.ndarray,
-            y: np.ndarray = None,
+            y: Optional[np.ndarray] = None,
             n_inputs: int = 0,
             episode_feature: bool = False) -> 'KoopmanPipeline':
         """Fit the Koopman pipeline.
@@ -2101,7 +2113,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         ----------
         X : np.ndarray
             Data matrix.
-        y : np.ndarray
+        y : Optional[np.ndarray]
             Ignored.
         n_inputs : int
             Number of input features at the end of ``X``.
@@ -2151,7 +2163,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
     def fit_transformers(
         self,
         X: np.ndarray,
-        y: np.ndarray = None,
+        y: Optional[np.ndarray] = None,
         n_inputs: int = 0,
         episode_feature: bool = False,
     ) -> 'KoopmanPipeline':
@@ -2163,7 +2175,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         ----------
         X : np.ndarray
             Data matrix.
-        y : np.ndarray
+        y : Optional[np.ndarray]
             Ignored.
         n_inputs : int
             Number of input features at the end of ``X``.
@@ -2339,7 +2351,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
             X_pred_inv = X_pred_pad_inv
         return X_pred_inv
 
-    def score(self, X: np.ndarray, y: np.ndarray = None) -> float:
+    def score(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> float:
         """Calculate prediction score.
 
         For more flexible scoring, see :func:`make_scorer`.
@@ -2348,7 +2360,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         ----------
         X : np.ndarray
             Data matrix.
-        y : np.ndarray
+        y : Optional[np.ndarray]
             Ignored.
 
         Returns
@@ -2451,11 +2463,11 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
     def predict_trajectory(
         self,
         X0_or_X: np.ndarray,
-        U: np.ndarray = None,
+        U: Optional[np.ndarray] = None,
         relift_state: bool = True,
         return_lifted: bool = False,
         return_input: bool = False,
-        episode_feature: bool = None,
+        episode_feature: Optional[bool] = None,
     ) -> np.ndarray:
         """Predict state trajectory given input for each episode.
 
@@ -2465,7 +2477,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
             Initial state if ``U`` is specified. If ``U`` is ``None``, then
             treated as the initial state and full input in one matrix, where
             the remaining states are ignored.
-        U : np.ndarray
+        U : Optional[np.ndarray]
             Input. Length of prediction is governed by length of input. If
             ``None``, input is taken from last features of ``X0_or_X``.
         relift_state : bool
@@ -2479,7 +2491,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         return_input : bool
             If true, return the input as well as the state. If false, return
             only the original state (default).
-        episode_feature : bool
+        episode_feature : Optional[bool]
             True if first feature indicates which episode a timestep is from.
             If ``None``, ``self.episode_feature_`` is used.
 
@@ -2680,15 +2692,15 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
     def plot_predicted_trajectory(
         self,
         X0_or_X: np.ndarray,
-        U: np.ndarray = None,
+        U: Optional[np.ndarray] = None,
         relift_state: bool = True,
         plot_lifted: bool = False,
         plot_input: bool = False,
-        episode_feature: bool = None,
+        episode_feature: Optional[bool] = None,
         plot_ground_truth: bool = True,
-        episode_style: str = None,
-        subplots_kw: Dict[str, Any] = None,
-        plot_kw: Dict[str, Any] = None,
+        episode_style: Optional[str] = None,
+        subplots_kw: Optional[Dict[str, Any]] = None,
+        plot_kw: Optional[Dict[str, Any]] = None,
     ) -> Tuple[plt.Figure, np.ndarray]:
         """Plot predicted trajectory.
 
@@ -2698,7 +2710,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
             Initial state if ``U`` is specified. If ``U`` is ``None``, then
             treated as the ground truth trajectory from which the initial state
             and full input are extracted.
-        U : np.ndarray
+        U : Optional[np.ndarray]
             Input. Length of prediction is governed by length of input. If
             ``None``, input is taken from last features of ``X0_or_X``.
         relift_state : bool
@@ -2712,19 +2724,19 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         plot_input : bool
             If true, plot the input as well as the state. If false, plot
             only the original state (default).
-        episode_feature : bool
+        episode_feature : Optional[bool]
             True if first feature indicates which episode a timestep is from.
             If ``None``, ``self.episode_feature_`` is used.
         plot_ground_truth : bool
             Plot contents of ``X0_or_X`` as ground truth if ``U`` is ``None``.
             Ignored if ``U`` is not ``None``.
-        episode_style : str
+        episode_style : Optional[str]
             If ``'columns'``, each episode is a column (default). If
             ``'overlay'``, states from each episode are plotted overtop of each
             other in different colors.
-        subplots_kw : Dict[str, Any] = None,
+        subplots_kw : Optional[Dict[str, Any]]
             Keyword arguments for :func:`plt.subplots()`.
-        plot_kw : Dict[str, Any] = None,
+        plot_kw : Optional[Dict[str, Any]]
             Keyword arguments for Matplotlib :func:`plt.Axes.plot()`.
 
         Returns
@@ -2845,10 +2857,10 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
 
     @staticmethod
     def make_scorer(
-        n_steps: int = None,
+        n_steps: Optional[int] = None,
         discount_factor: float = 1,
         regression_metric: Union[str, Callable] = 'neg_mean_squared_error',
-        regression_metric_kw: Dict[str, Any] = None,
+        regression_metric_kw: Optional[Dict[str, Any]] = None,
         error_score: Union[str, float] = np.nan,
         multistep: bool = True,
         relift_state: bool = True,
@@ -2868,7 +2880,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
 
         Parameters
         ----------
-        n_steps : int
+        n_steps : Optional[int]
             Number of steps ahead to predict. If ``None`` or longer than the
             episode, will score the entire episode.
 
@@ -2894,7 +2906,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
             the ``scikit-learn`` ones. That is, at least ``y_true``,
             ``y_pred``, ``sample_weight``, and ``multioutput``.
 
-        regression_metric_kw : Dict[str, Any]
+        regression_metric_kw : Optional[Dict[str, Any]]
             Keyword arguments for ``regression_method``. If ``sample_weight``
             keyword argument is specified, ``discount_factor`` is ignored.
 
@@ -2939,7 +2951,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         def koopman_pipeline_scorer(
             estimator: KoopmanPipeline,
             X: np.ndarray,
-            y: np.ndarray = None,
+            y: Optional[np.ndarray] = None,
         ) -> float:
             # Shift episodes
             X_unshifted, X_shifted = shift_episodes(
@@ -3020,7 +3032,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
     def _transform_feature_names(
         self,
         feature_names: np.ndarray,
-        format: str = None,
+        format: Optional[str] = None,
     ) -> np.ndarray:
         """Transform feature names.
 
@@ -3028,7 +3040,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         ----------
         feature_names : np.ndarray
             Feature names.
-        format : str
+        format : Optional[str]
             Feature name formatting method. Possible values are ``'plaintext'``
             (default if ``None``) or ``'latex'``.
 
@@ -3045,7 +3057,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
     def _split_state_input_episodes(
         self,
         X0_or_X: np.ndarray,
-        U: np.ndarray = None,
+        U: Optional[np.ndarray] = None,
         episode_feature: bool = False,
     ) -> List[Tuple[float, np.ndarray, np.ndarray]]:
         """Break initial conditions and inputs into episodes.
@@ -3056,7 +3068,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
             Initial state if ``U`` is specified. If ``U`` is ``None``, then
             treated as the initial state and full input in one matrix, where
             the remaining states are ignored.
-        U : np.ndarray
+        U : Optional[np.ndarray]
             Input. Length of prediction is governed by length of input. If
             ``None``, input is taken from last features of ``X0_or_X``.
         episode_feature : bool
@@ -3111,7 +3123,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         self,
         t_step: float,
         f_min: float = 0,
-        f_max: float = None,
+        f_max: Optional[float] = None,
         n_points: int = 1000,
         decibels: bool = True,
     ) -> Tuple[np.ndarray, np.ndarray]:
@@ -3124,7 +3136,7 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         f_min : float
             Minimum frequency to plot.
         f_max : float
-            Maximum frequency to plot.
+            Maximum frequency to plot. If ``None``, uses the Nyquist frequency.
         n_points : int
             Number of frequecy points to plot.
         decibels : bool
@@ -3155,11 +3167,11 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         self,
         t_step: float,
         f_min: float = 0,
-        f_max: float = None,
+        f_max: Optional[float] = None,
         n_points: int = 1000,
         decibels: bool = True,
-        subplots_kw: Dict[str, Any] = None,
-        plot_kw: Dict[str, Any] = None,
+        subplots_kw: Optional[Dict[str, Any]] = None,
+        plot_kw: Optional[Dict[str, Any]] = None,
     ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot frequency response of Koopman system.
 
@@ -3169,15 +3181,15 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
             Sampling timestep.
         f_min : float
             Minimum frequency to plot.
-        f_max : float
-            Maximum frequency to plot.
+        f_max : Optional[float]
+            Maximum frequency to plot. If ``None``, uses the Nyquist frequency.
         n_points : int
             Number of frequecy points to plot.
         decibels : bool
             Plot gain in dB (default is true).
-        subplots_kw : Dict[str, Any] = None,
+        subplots_kw : Optional[Dict[str, Any]]
             Keyword arguments for :func:`plt.subplots()`.
-        plot_kw : Dict[str, Any] = None,
+        plot_kw : Optional[Dict[str, Any]]
             Keyword arguments for Matplotlib :func:`plt.Axes.plot()`.
 
         Returns
@@ -3206,19 +3218,19 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
     def plot_eigenvalues(
         self,
         unit_circle: bool = True,
-        figure_kw: Dict[str, Any] = None,
-        subplot_kw: Dict[str, Any] = None,
-        plot_kw: Dict[str, Any] = None,
+        figure_kw: Optional[Dict[str, Any]] = None,
+        subplot_kw: Optional[Dict[str, Any]] = None,
+        plot_kw: Optional[Dict[str, Any]] = None,
     ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot eigenvalues of Koopman ``A`` matrix.
 
         Parameters
         ----------
-        figure_kw : Dict[str, Any] = None,
+        figure_kw : Optional[Dict[str, Any]]
             Keyword arguments for :func:`plt.figure()`.
-        subplot_kw : Dict[str, Any] = None,
+        subplot_kw : Optional[Dict[str, Any]]
             Keyword arguments for :func:`plt.subplot()`.
-        plot_kw : Dict[str, Any] = None,
+        plot_kw : Optional[Dict[str, Any]]
             Keyword arguments for Matplotlib :func:`plt.Axes.plot()`.
 
         Returns
@@ -3237,16 +3249,16 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
 
     def plot_koopman_matrix(
         self,
-        subplots_kw: Dict[str, Any] = None,
-        plot_kw: Dict[str, Any] = None,
+        subplots_kw: Optional[Dict[str, Any]] = None,
+        plot_kw: Optional[Dict[str, Any]] = None,
     ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot heatmap of Koopman matrices.
 
         Parameters
         ----------
-        subplots_kw : Dict[str, Any] = None,
+        subplots_kw : Optional[Dict[str, Any]]
             Keyword arguments for :func:`plt.subplots()`.
-        plot_kw : Dict[str, Any] = None,
+        plot_kw : Optional[Dict[str, Any]]
             Keyword arguments for Matplotlib :func:`plt.Axes.plot()`.
 
         Returns
@@ -3260,16 +3272,16 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
 
     def plot_svd(
         self,
-        subplots_kw: Dict[str, Any] = None,
-        plot_kw: Dict[str, Any] = None,
+        subplots_kw: Optional[Dict[str, Any]] = None,
+        plot_kw: Optional[Dict[str, Any]] = None,
     ) -> Tuple[plt.Figure, plt.Axes]:
         """Plot singular values of Koopman matrices.
 
         Parameters
         ----------
-        subplots_kw : Dict[str, Any] = None,
+        subplots_kw : Optional[Dict[str, Any]]
             Keyword arguments for :func:`plt.subplots()`.
-        plot_kw : Dict[str, Any] = None,
+        plot_kw : Optional[Dict[str, Any]]
             Keyword arguments for Matplotlib :func:`plt.Axes.plot()`.
 
         Returns
@@ -3285,10 +3297,10 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
 def score_trajectory(
     X_predicted: np.ndarray,
     X_expected: np.ndarray,
-    n_steps: int = None,
+    n_steps: Optional[int] = None,
     discount_factor: float = 1,
     regression_metric: Union[str, Callable] = 'neg_mean_squared_error',
-    regression_metric_kw: Dict[str, Any] = None,
+    regression_metric_kw: Optional[Dict[str, Any]] = None,
     error_score: Union[str, float] = np.nan,
     min_samples: int = 1,
     episode_feature: bool = False,
@@ -3303,7 +3315,7 @@ def score_trajectory(
     X_expected : np.ndarray
         Expected state data matrix.
 
-    n_steps : int
+    n_steps : Optional[int]
         Number of steps ahead to predict. If ``None`` or longer than the
         episode, will score the entire episode.
 
@@ -3329,7 +3341,7 @@ def score_trajectory(
         ``scikit-learn`` ones. That is, at least ``y_true``, ``y_pred``,
         ``sample_weight``, and ``multioutput``.
 
-    regression_metric_kw : Dict[str, Any]
+    regression_metric_kw : Optional[Dict[str, Any]]
         Keyword arguments for ``regression_method``. If ``sample_weight``
         keyword argument is specified, ``discount_factor`` is ignored.
 
@@ -3681,7 +3693,7 @@ def combine_episodes(episodes: List[Tuple[float, np.ndarray]],
 
 def _weights_from_data_matrix(
     X: np.ndarray,
-    n_steps: int = None,
+    n_steps: Optional[int] = None,
     discount_factor: float = 1,
     episode_feature: bool = False,
 ) -> np.ndarray:
@@ -3691,7 +3703,7 @@ def _weights_from_data_matrix(
     ----------
     X : np.ndarray
         Data matrix
-    n_steps : int
+    n_steps : Optional[int]
         Number of steps ahead to predict. If ``None`` or longer than the
         episode, will weight the entire episode.
     discount_factor : float

--- a/pykoop/lifting_functions.py
+++ b/pykoop/lifting_functions.py
@@ -1008,6 +1008,8 @@ class ConstantLiftingFn(koopman_pipeline.EpisodeIndependentLiftingFn):
 class DelayLiftingFn(koopman_pipeline.EpisodeDependentLiftingFn):
     """Lifting function to generate delay coordinates for state and input.
 
+    See [PD20]_ for an in-depth treatment of time-delay embeddings.
+
     Attributes
     ----------
     n_features_in_ : int

--- a/pykoop/lifting_functions.py
+++ b/pykoop/lifting_functions.py
@@ -4,7 +4,7 @@ All of the lifting functions included in this module adhere to the interface
 defined in :class:`KoopmanLiftingFn`.
 """
 
-from typing import Callable, Tuple, Union
+from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
 import sklearn.base
@@ -76,13 +76,13 @@ class SkLearnLiftingFn(koopman_pipeline.EpisodeIndependentLiftingFn):
 
     def __init__(
         self,
-        transformer: sklearn.base.BaseEstimator = None,
+        transformer: Optional[sklearn.base.BaseEstimator] = None,
     ) -> None:
         """Instantiate :class:`SkLearnLiftingFn`.
 
         Parameters
         ----------
-        transformer : sklearn.base.BaseEstimator
+        transformer : Optional[sklearn.base.BaseEstimator]
             Transformer to wrap.
         """
         self.transformer = transformer
@@ -107,7 +107,7 @@ class SkLearnLiftingFn(koopman_pipeline.EpisodeIndependentLiftingFn):
     def _transform_feature_names(
         self,
         feature_names: np.ndarray,
-        format: str = None,
+        format: Optional[str] = None,
     ) -> np.ndarray:
         # noqa: D102
         if format == 'latex':
@@ -264,7 +264,7 @@ class PolynomialLiftingFn(koopman_pipeline.EpisodeIndependentLiftingFn):
     def _transform_feature_names(
         self,
         feature_names: np.ndarray,
-        format: str = None,
+        format: Optional[str] = None,
     ) -> np.ndarray:
         # noqa: D102
         if format == 'latex':
@@ -396,7 +396,7 @@ class BilinearInputLiftingFn(koopman_pipeline.EpisodeIndependentLiftingFn):
     def _transform_feature_names(
         self,
         feature_names: np.ndarray,
-        format: str = None,
+        format: Optional[str] = None,
     ) -> np.ndarray:
         # noqa: D102
         if format == 'latex':
@@ -573,9 +573,9 @@ class RbfLiftingFn(koopman_pipeline.EpisodeIndependentLiftingFn):
     def __init__(
         self,
         rbf: Union[str, Callable[[np.ndarray], np.ndarray]] = 'gaussian',
-        centers: centers.Centers = None,
+        centers: Optional[centers.Centers] = None,
         shape: float = 1,
-        offset: float = None,
+        offset: Optional[float] = None,
     ) -> None:
         """Instantiate :class:`RbfLiftingFn`.
 
@@ -599,7 +599,7 @@ class RbfLiftingFn(koopman_pipeline.EpisodeIndependentLiftingFn):
             can be used. It must be vectorized, i.e., it must be callable
             with an array of radii and operate on it elementwise.
 
-        centers : centers.Centers
+        centers : Optional[pykoop.Centers]
             Estimator to generate centers from data. Number of lifting
             functions is controlled by the number of centers generated.
             Defaults to :class:`QmcCenters` with its default arguments.
@@ -608,7 +608,7 @@ class RbfLiftingFn(koopman_pipeline.EpisodeIndependentLiftingFn):
             Shape parameter. Must be greater than zero. Larger numbers produce
             "sharper" basis functions. Default is ``1``.
 
-        offset : float
+        offset : Optional[float]
             Offset to apply to the norm. Not needed unless RBF is not defined
             for zero radius. Default is ``None``, where zero is used for all
             ``rbf`` values except ``'thin_plate'``, where ``1e-3`` is used.
@@ -691,7 +691,7 @@ class RbfLiftingFn(koopman_pipeline.EpisodeIndependentLiftingFn):
     def _transform_feature_names(
         self,
         feature_names: np.ndarray,
-        format: str = None,
+        format: Optional[str] = None,
     ) -> np.ndarray:
         if format == 'latex':
             pre = '{'
@@ -805,12 +805,15 @@ class KernelApproxLiftingFn(koopman_pipeline.EpisodeIndependentLiftingFn):
     random_state=1234))
     """
 
-    def __init__(self, kernel_approx: KernelApproxEstimator = None) -> None:
+    def __init__(
+        self,
+        kernel_approx: Optional[KernelApproxEstimator] = None,
+    ) -> None:
         """Instantiate :class:`KernelApproxLiftingFn`.
 
         Attributes
         ----------
-        kernel_approx : KernelApproxEstimator
+        kernel_approx : Optional[KernelApproxEstimator]
             Estimator that approximates feature maps from kernels. Can be an
             instance of :class:`pykoop.KernelApprox` or one of the estimators
             from :mod:`sklearn.kernel_approximation`. Defaults to
@@ -873,7 +876,7 @@ class KernelApproxLiftingFn(koopman_pipeline.EpisodeIndependentLiftingFn):
     def _transform_feature_names(
         self,
         feature_names: np.ndarray,
-        format: str = None,
+        format: Optional[str] = None,
     ) -> np.ndarray:
         if format == 'latex':
             pre = '{'
@@ -981,7 +984,7 @@ class ConstantLiftingFn(koopman_pipeline.EpisodeIndependentLiftingFn):
     def _transform_feature_names(
         self,
         feature_names: np.ndarray,
-        format: str = None,
+        format: Optional[str] = None,
     ) -> np.ndarray:
         # Deal with episode feature
         if self.episode_feature_:
@@ -1055,9 +1058,11 @@ class DelayLiftingFn(koopman_pipeline.EpisodeDependentLiftingFn):
     >>> Xt_msd = delay.transform(X_msd[:3, :])
     """
 
-    def __init__(self,
-                 n_delays_state: int = 0,
-                 n_delays_input: int = 0) -> None:
+    def __init__(
+        self,
+        n_delays_state: int = 0,
+        n_delays_input: int = 0,
+    ) -> None:
         """Instantiate :class:`DelayLiftingFn`.
 
         Parameters
@@ -1119,7 +1124,7 @@ class DelayLiftingFn(koopman_pipeline.EpisodeDependentLiftingFn):
     def _transform_feature_names(
         self,
         feature_names: np.ndarray,
-        format: str = None,
+        format: Optional[str] = None,
     ) -> np.ndarray:
         # noqa: D102
         if format == 'latex':

--- a/pykoop/lmi_regressors.py
+++ b/pykoop/lmi_regressors.py
@@ -123,7 +123,7 @@ class LmiEdmd(LmiRegressor):
         Matrix two norm or nuclear norm regularization coefficient used.
     tsvd_ : pykoop.Tsvd
         Fit truncated SVD object.
-    solver_params_ : Dict[str, Any]
+    solver_params_ : Optional[Dict[str, Any]]
         Solver parameters used (defaults merged with constructor input).
     n_features_in_ : int
         Number of features input, including episode feature.
@@ -183,15 +183,17 @@ class LmiEdmd(LmiRegressor):
     square_norm=True))
     """
 
-    def __init__(self,
-                 alpha: float = 0,
-                 ratio: float = 1,
-                 reg_method: str = 'tikhonov',
-                 inv_method: str = 'svd',
-                 tsvd: tsvd.Tsvd = None,
-                 square_norm: bool = False,
-                 picos_eps: float = 0,
-                 solver_params: Dict[str, Any] = None) -> None:
+    def __init__(
+        self,
+        alpha: float = 0,
+        ratio: float = 1,
+        reg_method: str = 'tikhonov',
+        inv_method: str = 'svd',
+        tsvd: Optional[tsvd.Tsvd] = None,
+        square_norm: bool = False,
+        picos_eps: float = 0,
+        solver_params: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Instantiate :class:`LmiEdmd`.
 
         To disable regularization, use ``alpha=0`` paired with
@@ -230,7 +232,7 @@ class LmiEdmd(LmiRegressor):
             - ``'sqrt'`` -- split ``H`` using :func:`scipy.linalg.sqrtm()`, or
             - ``'svd'`` -- split ``H`` using a singular value decomposition.
 
-        tsvd : pykoop.Tsvd()
+        tsvd : Optional[pykoop.Tsvd]
             Singular value truncation method if ``inv_method='svd'``. If
             ``None``, economy SVD is used.
 
@@ -243,7 +245,7 @@ class LmiEdmd(LmiRegressor):
             Tolerance used for strict LMIs. If nonzero, should be larger than
             solver tolerance.
 
-        solver_params : Dict[str, Any]
+        solver_params : Optional[Dict[str, Any]]
             Parameters passed to PICOS :func:`picos.Problem.solve()`. By
             default, allows chosen solver to select its own tolerances.
         """
@@ -423,7 +425,7 @@ class LmiDmdc(LmiRegressor):
         Fit truncated SVD object for shifted data matrix.
     U_hat_ : np.ndarray
         Reduced Koopman matrix for debugging.
-    solver_params_ : Dict[str, Any]
+    solver_params_ : Optional[Dict[str, Any]]
         Solver parameters used (defaults merged with constructor input).
     n_features_in_ : int
         Number of features input, including episode feature.
@@ -484,15 +486,17 @@ class LmiDmdc(LmiRegressor):
     tsvd_unshifted=Tsvd(truncation='known_noise', truncation_param=0.1)))
     """
 
-    def __init__(self,
-                 alpha: float = 0,
-                 ratio: float = 1,
-                 tsvd_unshifted: tsvd.Tsvd = None,
-                 tsvd_shifted: tsvd.Tsvd = None,
-                 reg_method: str = 'tikhonov',
-                 square_norm: bool = False,
-                 picos_eps: float = 0,
-                 solver_params: Dict[str, Any] = None) -> None:
+    def __init__(
+        self,
+        alpha: float = 0,
+        ratio: float = 1,
+        tsvd_unshifted: Optional[tsvd.Tsvd] = None,
+        tsvd_shifted: Optional[tsvd.Tsvd] = None,
+        reg_method: str = 'tikhonov',
+        square_norm: bool = False,
+        picos_eps: float = 0,
+        solver_params: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Instantiate :class:`LmiDmdc`.
 
         Parameters
@@ -506,11 +510,11 @@ class LmiDmdc(LmiRegressor):
             regularization. If ``ratio=1``, no Tikhonov regularization is
             used. Cannot be zero. Ignored if ``reg_method='tikhonov'``.
 
-        tsvd_unshifted : pykoop.Tsvd
+        tsvd_unshifted : Optional[pykoop.Tsvd]
             Singular value truncation method used to change basis of unshifted
             data matrix. If ``None``, economy SVD is used.
 
-        tsvd_shifted : pykoop.Tsvd
+        tsvd_shifted : Optional[pykoop.Tsvd]
             Singular value truncation method used to change basis of shifted
             data matrix. If ``None``, economy SVD is used.
 
@@ -533,7 +537,7 @@ class LmiDmdc(LmiRegressor):
             Tolerance used for strict LMIs. If nonzero, should be larger than
             solver tolerance.
 
-        solver_params : Dict[str, Any]
+        solver_params : Optional[Dict[str, Any]]
             Parameters passed to PICOS :func:`picos.Problem.solve()`. By
             default, allows chosen solver to select its own tolerances.
         """
@@ -695,7 +699,7 @@ class LmiEdmdSpectralRadiusConstr(LmiRegressor):
         Reason iteration stopped.
     n_iter_ : int
         Number of iterations
-    solver_params_ : Dict[str, Any]
+    solver_params_ : Optional[Dict[str, Any]]
         Solver parameters used (defaults merged with constructor input).
     n_features_in_ : int
         Number of features input, including episode feature.
@@ -723,16 +727,18 @@ class LmiEdmdSpectralRadiusConstr(LmiRegressor):
     KoopmanPipeline(regressor=LmiEdmdSpectralRadiusConstr(spectral_radius=0.9))
     """
 
-    def __init__(self,
-                 spectral_radius: float = 1.0,
-                 max_iter: int = 100,
-                 iter_atol: float = 1e-6,
-                 iter_rtol: float = 0,
-                 alpha: float = 0,
-                 inv_method: str = 'svd',
-                 tsvd: tsvd.Tsvd = None,
-                 picos_eps: float = 0,
-                 solver_params: Dict[str, Any] = None) -> None:
+    def __init__(
+        self,
+        spectral_radius: float = 1.0,
+        max_iter: int = 100,
+        iter_atol: float = 1e-6,
+        iter_rtol: float = 0,
+        alpha: float = 0,
+        inv_method: str = 'svd',
+        tsvd: Optional[tsvd.Tsvd] = None,
+        picos_eps: float = 0,
+        solver_params: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Instantiate :class:`LmiEdmdSpectralRadiusConstr`.
 
         To disable regularization, use ``alpha=0``.
@@ -767,7 +773,7 @@ class LmiEdmdSpectralRadiusConstr(LmiRegressor):
             - ``'sqrt'`` -- split ``H`` using :func:`scipy.linalg.sqrtm()`, or
             - ``'svd'`` -- split ``H`` using a singular value decomposition.
 
-         tsvd : pykoop.Tsvd
+         tsvd : Optional[pykoop.Tsvd]
             Singular value truncation method if ``inv_method='svd'``. If
             ``None``, economy SVD is used.
 
@@ -775,7 +781,7 @@ class LmiEdmdSpectralRadiusConstr(LmiRegressor):
             Tolerance used for strict LMIs. If nonzero, should be larger than
             solver tolerance.
 
-        solver_params : Dict[str, Any]
+        solver_params : Optional[Dict[str, Any]]
             Parameters passed to PICOS :func:`picos.Problem.solve()`. By
             default, allows chosen solver to select its own tolerances.
         """
@@ -941,7 +947,7 @@ class LmiDmdcSpectralRadiusConstr(LmiRegressor):
         Reason iteration stopped.
     n_iter_ : int
         Number of iterations
-    solver_params_ : Dict[str, Any]
+    solver_params_ : Optional[Dict[str, Any]]
         Solver parameters used (defaults merged with constructor input).
     n_features_in_ : int
         Number of features input, including episode feature.
@@ -973,16 +979,18 @@ class LmiDmdcSpectralRadiusConstr(LmiRegressor):
     tsvd_unshifted=Tsvd(truncation='cutoff', truncation_param=1e-06)))
     """
 
-    def __init__(self,
-                 spectral_radius: float = 1.0,
-                 max_iter: int = 100,
-                 iter_atol: float = 1e-6,
-                 iter_rtol: float = 0,
-                 alpha: float = 0,
-                 tsvd_unshifted: tsvd.Tsvd = None,
-                 tsvd_shifted: tsvd.Tsvd = None,
-                 picos_eps: float = 0,
-                 solver_params: Dict[str, Any] = None) -> None:
+    def __init__(
+        self,
+        spectral_radius: float = 1.0,
+        max_iter: int = 100,
+        iter_atol: float = 1e-6,
+        iter_rtol: float = 0,
+        alpha: float = 0,
+        tsvd_unshifted: Optional[tsvd.Tsvd] = None,
+        tsvd_shifted: Optional[tsvd.Tsvd] = None,
+        picos_eps: float = 0,
+        solver_params: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Instantiate :class:`LmiDmdcSpectralRadiusConstr`.
 
         To disable regularization, use ``alpha=0``.
@@ -999,16 +1007,16 @@ class LmiDmdcSpectralRadiusConstr(LmiRegressor):
             Relative tolerance for change in objective function value.
         alpha : float
             Tikhonov regularization coefficient.
-        tsvd_unshifted : pykoop.Tsvd
+        tsvd_unshifted : Optional[pykoop.Tsvd]
             Singular value truncation method used to change basis of unshifted
             data matrix. If ``None``, economy SVD is used.
-        tsvd_shifted : pykoop.Tsvd
+        tsvd_shifted : Optional[pykoop.Tsvd]
             Singular value truncation method used to change basis of shifted
             data matrix. If ``None``, economy SVD is used.
         picos_eps : float
             Tolerance used for strict LMIs. If nonzero, should be larger than
             solver tolerance.
-        solver_params : Dict[str, Any]
+        solver_params : Optional[Dict[str, Any]]
             Parameters passed to PICOS :func:`picos.Problem.solve()`. By
             default, allows chosen solver to select its own tolerances.
         """
@@ -1199,7 +1207,7 @@ class LmiEdmdHinfReg(LmiRegressor):
         Reason iteration stopped.
     n_iter_ : int
         Number of iterations
-    solver_params_ : Dict[str, Any]
+    solver_params_ : Optional[Dict[str, Any]]
         Solver parameters used (defaults merged with constructor input).
     n_features_in_ : int
         Number of features input, including episode feature.
@@ -1248,16 +1256,16 @@ class LmiEdmdHinfReg(LmiRegressor):
         self,
         alpha: float = 1,
         ratio: float = 1,
-        weight: Tuple[str, np.ndarray, np.ndarray, np.ndarray,
-                      np.ndarray] = None,
+        weight: Optional[Tuple[str, np.ndarray, np.ndarray, np.ndarray,
+                               np.ndarray]] = None,
         max_iter: int = 100,
         iter_atol: float = 1e-6,
         iter_rtol: float = 0,
         inv_method: str = 'svd',
-        tsvd: tsvd.Tsvd = None,
+        tsvd: Optional[tsvd.Tsvd] = None,
         square_norm: bool = False,
         picos_eps: float = 0,
-        solver_params: Dict[str, Any] = None,
+        solver_params: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Instantiate :class:`LmiEdmdHinfReg`.
 
@@ -1272,7 +1280,8 @@ class LmiEdmdHinfReg(LmiRegressor):
             Ratio of H-infinity norm to use in mixed regularization. If
             ``ratio=1``, no Tikhonov regularization is used. Cannot be zero.
 
-        weight : Tuple[str, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+        weight : Optional[Tuple[str, np.ndarray, np.ndarray, np.ndarray,
+                                np.ndarray]]
             Tuple containing weight type (``'pre'`` or ``'post'``), and the
             weight state space matrices (``A``, ``B``, ``C``, and ``D``). If
             ``None``, no weighting is used.
@@ -1298,7 +1307,7 @@ class LmiEdmdHinfReg(LmiRegressor):
             - ``'sqrt'`` -- split ``H`` using :func:`scipy.linalg.sqrtm()`, or
             - ``'svd'`` -- split ``H`` using a singular value decomposition.
 
-         tsvd : pykoop.Tsvd
+         tsvd : Optional[pykoop.Tsvd]
             Singular value truncation method if ``inv_method='svd'``. If
             ``None``, economy SVD is used.
 
@@ -1311,7 +1320,7 @@ class LmiEdmdHinfReg(LmiRegressor):
             Tolerance used for strict LMIs. If nonzero, should be larger than
             solver tolerance.
 
-        solver_params : Dict[str, Any]
+        solver_params : Optional[Dict[str, Any]]
             Parameters passed to PICOS :func:`picos.Problem.solve()`. By
             default, allows chosen solver to select its own tolerances.
         """
@@ -1586,16 +1595,16 @@ class LmiDmdcHinfReg(LmiRegressor):
         self,
         alpha: float = 1,
         ratio: float = 1,
-        weight: Tuple[str, np.ndarray, np.ndarray, np.ndarray,
-                      np.ndarray] = None,
+        weight: Optional[Tuple[str, np.ndarray, np.ndarray, np.ndarray,
+                               np.ndarray]] = None,
         max_iter: int = 100,
         iter_atol: float = 1e-6,
         iter_rtol: float = 0,
-        tsvd_unshifted: tsvd.Tsvd = None,
-        tsvd_shifted: tsvd.Tsvd = None,
+        tsvd_unshifted: Optional[tsvd.Tsvd] = None,
+        tsvd_shifted: Optional[tsvd.Tsvd] = None,
         square_norm: bool = False,
         picos_eps: float = 0,
-        solver_params: Dict[str, Any] = None,
+        solver_params: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Instantiate :class:`LmiDmdcHinfReg`.
 
@@ -1608,7 +1617,8 @@ class LmiDmdcHinfReg(LmiRegressor):
         ratio : float
             Ratio of H-infinity norm to use in mixed regularization. If
             ``ratio=1``, no Tikhonov regularization is used. Cannot be zero.
-        weight : Tuple[str, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+        weight : Optional[Tuple[str, np.ndarray, np.ndarray, np.ndarray,
+                                np.ndarray]]
             Tuple containing weight type (``'pre'`` or ``'post'``), and the
             weight state space matrices (``A``, ``B``, ``C``, and ``D``). If
             ``None``, no weighting is used.
@@ -1618,10 +1628,10 @@ class LmiDmdcHinfReg(LmiRegressor):
             Absolute tolerance for change in objective function value.
         iter_rtol : float
             Relative tolerance for change in objective function value.
-        tsvd_unshifted : pykoop.Tsvd
+        tsvd_unshifted : Optional[pykoop.Tsvd]
             Singular value truncation method used to change basis of unshifted
             data matrix. If ``None``, economy SVD is used.
-        tsvd_shifted : pykoop.Tsvd
+        tsvd_shifted : Optional[pykoop.Tsvd]
             Singular value truncation method used to change basis of shifted
             data matrix. If ``None``, economy SVD is used.
         square_norm : bool
@@ -1631,7 +1641,7 @@ class LmiDmdcHinfReg(LmiRegressor):
         picos_eps : float
             Tolerance used for strict LMIs. If nonzero, should be larger than
             solver tolerance.
-        solver_params : Dict[str, Any]
+        solver_params : Optional[Dict[str, Any]]
             Parameters passed to PICOS :func:`picos.Problem.solve()`. By
             default, allows chosen solver to select its own tolerances.
         """
@@ -1908,14 +1918,14 @@ class LmiEdmdDissipativityConstr(LmiRegressor):
     def __init__(
         self,
         alpha: float = 1,
-        supply_rate: np.ndarray = None,
+        supply_rate: Optional[np.ndarray] = None,
         max_iter: int = 100,
         iter_atol: float = 1e-6,
         iter_rtol: float = 0,
         inv_method: str = 'svd',
-        tsvd: tsvd.Tsvd = None,
+        tsvd: Optional[tsvd.Tsvd] = None,
         picos_eps: float = 0,
-        solver_params: Dict[str, Any] = None,
+        solver_params: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Instantiate :class:`LmiEdmdDissipativityConstr`.
 
@@ -1933,7 +1943,7 @@ class LmiEdmdDissipativityConstr(LmiRegressor):
         alpha : float
             Regularization coefficient. Cannot be zero.
 
-        supply_rate : np.ndarray
+        supply_rate : Optional[np.ndarray]
             Supply rate matrix ``Xi``, where ``s(u, y) = -[y, u] Xi [y; u]``.
             If ``None``, the an L2 gain of ``gamma=1`` is imposed.
 
@@ -1958,7 +1968,7 @@ class LmiEdmdDissipativityConstr(LmiRegressor):
             - ``'sqrt'`` -- split ``H`` using :func:`scipy.linalg.sqrtm()`, or
             - ``'svd'`` -- split ``H`` using a singular value decomposition.
 
-         tsvd : pykoop.Tsvd
+         tsvd : Optional[pykoop.Tsvd]
             Singular value truncation method if ``inv_method='svd'``. If
             ``None``, economy SVD is used.
 
@@ -1966,7 +1976,7 @@ class LmiEdmdDissipativityConstr(LmiRegressor):
             Tolerance used for strict LMIs. If nonzero, should be larger than
             solver tolerance.
 
-        solver_params : Dict[str, Any]
+        solver_params : Optional[Dict[str, Any]]
             Parameters passed to PICOS :func:`picos.Problem.solve()`. By
             default, allows chosen solver to select its own tolerances.
         """
@@ -2180,10 +2190,10 @@ class LmiHinfZpkMeta(sklearn.base.BaseEstimator, sklearn.base.RegressorMixin):
 
     def __init__(
         self,
-        hinf_regressor: koopman_pipeline.KoopmanRegressor = None,
+        hinf_regressor: Optional[koopman_pipeline.KoopmanRegressor] = None,
         type: str = 'post',
-        zeros: Union[float, np.ndarray] = None,
-        poles: Union[float, np.ndarray] = None,
+        zeros: Union[float, np.ndarray, None] = None,
+        poles: Union[float, np.ndarray, None] = None,
         gain: float = 1,
         discretization: str = 'bilinear',
         t_step: float = 1,
@@ -2193,17 +2203,17 @@ class LmiHinfZpkMeta(sklearn.base.BaseEstimator, sklearn.base.RegressorMixin):
 
         Parameters
         ----------
-        hinf_regressor : koopman_pipeline.KoopmanRegressor
+        hinf_regressor : Optional[koopman_pipeline.KoopmanRegressor]
             Instance of :class:`LmiEdmdHinfReg` or :class:`LmiDmdcHinfReg`.
 
         type : str
             Type of weight (``'pre'`` or ``'post'``).
 
-        zeros : Union[float, np.ndarray]
+        zeros : Union[float, np.ndarray, None]
             Filter zeros. If ``None``, no zeros are used. Accepts scalar input
             if only one zero is required.
 
-        poles : Union[float, np.ndarray]
+        poles : Union[float, np.ndarray, None]
             Filter poles. If ``None``, no poles are used. Accepts scalar input
             if only one pole is required.
 
@@ -2262,11 +2272,13 @@ class LmiHinfZpkMeta(sklearn.base.BaseEstimator, sklearn.base.RegressorMixin):
         self.t_step = t_step
         self.units = units
 
-    def fit(self,
-            X: np.ndarray,
-            y: np.ndarray = None,
-            n_inputs: int = 0,
-            episode_feature: bool = False) -> 'LmiHinfZpkMeta':
+    def fit(
+        self,
+        X: np.ndarray,
+        y: Optional[np.ndarray] = None,
+        n_inputs: int = 0,
+        episode_feature: bool = False,
+    ) -> 'LmiHinfZpkMeta':
         """Fit the regressor.
 
         If only ``X`` is specified, the regressor will compute its unshifted
@@ -2279,7 +2291,7 @@ class LmiHinfZpkMeta(sklearn.base.BaseEstimator, sklearn.base.RegressorMixin):
         X : np.ndarray
             Full data matrix if ``y=None``. Unshifted data matrix if ``y`` is
             specified.
-        y : np.ndarray
+        y : Optional[np.ndarray]
             Optional shifted data matrix. If ``None``, shifted data matrix is
             computed using ``X``.
         n_inputs : int
@@ -2370,7 +2382,7 @@ def _create_ss(
     U: np.ndarray,
     weight: Optional[Tuple[str, np.ndarray, np.ndarray, np.ndarray,
                            np.ndarray]],
-    Q_hat: np.ndarray = None,
+    Q_hat: Optional[np.ndarray] = None,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Augment Koopman system with weight if present.
 
@@ -2384,7 +2396,7 @@ def _create_ss(
         Tuple containing weight type (``'pre'`` or ``'post'``), and the
         weight state space matrices (``A``, ``B``, ``C``, and ``D``). If
         ``None``, no weighting is used.
-    Q_hat : np.ndarray
+    Q_hat : Optioanl[np.ndarray]
         Left singular vectors of shifted data matrix. Used to construct ``C``
         matrix. Should only be used with DMDc methods.
 

--- a/pykoop/regressors.py
+++ b/pykoop/regressors.py
@@ -5,7 +5,7 @@ defined in :class:`KoopmanRegressor`.
 """
 
 import logging
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import numpy as np
 import sklearn.base
@@ -119,12 +119,15 @@ class EdmdMeta(koopman_pipeline.KoopmanRegressor):
     KoopmanPipeline(regressor=EdmdMeta(regressor=Lasso(alpha=1)))
     """
 
-    def __init__(self, regressor: sklearn.base.BaseEstimator = None) -> None:
+    def __init__(
+        self,
+        regressor: Optional[sklearn.base.BaseEstimator] = None,
+    ) -> None:
         """Instantiate :class:`EdmdMeta`.
 
         Parameters
         ----------
-        regressor : sklearn.base.BaseEstimator
+        regressor : Optional[sklearn.base.BaseEstimator]
             Wrapped ``scikit-learn`` regressor. Defaults to
             :class:`sklearn.linear_model.LinearRegression`.
         """
@@ -204,8 +207,8 @@ class Dmdc(koopman_pipeline.KoopmanRegressor):
     def __init__(
         self,
         mode_type: str = 'projected',
-        tsvd_unshifted: tsvd.Tsvd = None,
-        tsvd_shifted: tsvd.Tsvd = None,
+        tsvd_unshifted: Optional[tsvd.Tsvd] = None,
+        tsvd_shifted: Optional[tsvd.Tsvd] = None,
     ) -> None:
         """Instantiate :class:`Dmdc`.
 
@@ -213,10 +216,10 @@ class Dmdc(koopman_pipeline.KoopmanRegressor):
         ----------
         mode_type : str
             DMD mode type, either ``'exact'`` or ``'projected'``.
-        tsvd_unshifted : pykoop.Tsvd
+        tsvd_unshifted : Optional[pykoop.Tsvd]
             Singular value truncation method used to change basis of unshifted
             data matrix. If ``None``, economy SVD is used.
-        tsvd_shifted : pykoop.Tsvd
+        tsvd_shifted : Optional[pykoop.Tsvd]
             Singular value truncation method used to change basis of shifted
             data matrix. If ``None``, economy SVD is used.
         """
@@ -327,16 +330,18 @@ class Dmd(koopman_pipeline.KoopmanRegressor):
         'ensure_min_samples': 2,
     }
 
-    def __init__(self,
-                 mode_type: str = 'projected',
-                 tsvd: tsvd.Tsvd = None) -> None:
+    def __init__(
+        self,
+        mode_type: str = 'projected',
+        tsvd: Optional[tsvd.Tsvd] = None,
+    ) -> None:
         """Instantiate :class:`Dmd`.
 
         Parameters
         ----------
         mode_type : str
             DMD mode type, either ``'exact'`` or ``'projected'``.
-        tsvd : pykoop.Tsvd
+        tsvd : Optional[pykoop.Tsvd]
             Truncated singular value object used to change bases. If ``None``,
             economy SVD is used.
 
@@ -468,12 +473,12 @@ class DataRegressor(koopman_pipeline.KoopmanRegressor):
     KoopmanPipeline(regressor=DataRegressor(coef=array(...
     """
 
-    def __init__(self, coef: np.ndarray = None) -> None:
+    def __init__(self, coef: Optional[np.ndarray] = None) -> None:
         """Instantiate :class:`DataRegressor`.
 
         Parameters
         ----------
-        coef : np.ndarray
+        coef : Optional[np.ndarray]
             Coefficient matrix to copy to ``coef_``. If ``None``, an
             appropriately-sized zero matrix is used.
         """

--- a/pykoop/regressors.py
+++ b/pykoop/regressors.py
@@ -462,7 +462,7 @@ class DataRegressor(koopman_pipeline.KoopmanRegressor):
     library and you want to use ``pykoop`` to evaluate its performance.
 
     >>> kp = pykoop.KoopmanPipeline(regressor=pykoop.DataRegressor(
-    ...     coef=np.array([[0, 1, 0], [-0.5, -0.5, 1]]).T)
+    ...     coef=np.array([[0.0, -0.5], [1.0, -0.5], [0.0, 1.0]]).T)
     ... )
     >>> kp.fit(X_msd, n_inputs=1, episode_feature=True)
     KoopmanPipeline(regressor=DataRegressor(coef=array(...

--- a/pykoop/regressors.py
+++ b/pykoop/regressors.py
@@ -459,15 +459,14 @@ class DataRegressor(koopman_pipeline.KoopmanRegressor):
     --------
     Create a Koopman pipeline with the Koopman matrix forced to be::
 
-        0.0 -0.5
-        1.0 -0.5
-        0.0  1.0
+         0.0  1.0 0.0
+        -0.5 -0.5 1.0
 
     You may want to do this because you have a Koopman matrix from another
     library and you want to use ``pykoop`` to evaluate its performance.
 
     >>> kp = pykoop.KoopmanPipeline(regressor=pykoop.DataRegressor(
-    ...     coef=np.array([[0.0, -0.5], [1.0, -0.5], [0.0, 1.0]]).T)
+    ...     coef=np.array([[0.0, 1.0, 0.0], [-0.5, -0.5, 1.0]]).T)
     ... )
     >>> kp.fit(X_msd, n_inputs=1, episode_feature=True)
     KoopmanPipeline(regressor=DataRegressor(coef=array(...

--- a/pykoop/tsvd.py
+++ b/pykoop/tsvd.py
@@ -1,6 +1,7 @@
 """Truncated singular value decomposition."""
 
 import logging
+from typing import Optional
 
 import numpy as np
 import optht
@@ -25,9 +26,11 @@ class Tsvd(sklearn.base.BaseEstimator):
         Number of features input.
     """
 
-    def __init__(self,
-                 truncation: str = 'economy',
-                 truncation_param: float = None) -> None:
+    def __init__(
+        self,
+        truncation: str = 'economy',
+        truncation_param: Optional[float] = None,
+    ) -> None:
         """Instantiate :class:`Tsvd`.
 
         Parameters
@@ -44,7 +47,7 @@ class Tsvd(sklearn.base.BaseEstimator):
               or
             - ``'rank'`` -- truncate singular values to a fixed rank.
 
-        truncation_param : float
+        truncation_param : Optional[float]
             Parameter whose interpretation is based on the truncation method.
             For each truncation method, ``truncation_param`` is interpreted as
 
@@ -97,14 +100,14 @@ class Tsvd(sklearn.base.BaseEstimator):
         self.truncation = truncation
         self.truncation_param = truncation_param
 
-    def fit(self, X: np.ndarray, y: np.ndarray = None) -> 'Tsvd':
+    def fit(self, X: np.ndarray, y: Optional[np.ndarray] = None) -> 'Tsvd':
         """Compute the truncated singular value decomposition.
 
         Parameters
         ----------
         X : np.ndarray
             Data matrix.
-        y : np.ndarray
+        y : Optional[np.ndarray]
             Ignored.
 
         Returns

--- a/pykoop/util.py
+++ b/pykoop/util.py
@@ -1,6 +1,6 @@
 """Utilities for data generation and preprocessing."""
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
 from scipy import interpolate, signal
@@ -60,14 +60,16 @@ class AnglePreprocessor(koopman_pipeline.EpisodeIndependentLiftingFn):
     >>> X_pend_pp = angle_pp.transform(X_pend)
     """
 
-    def __init__(self,
-                 angle_features: np.ndarray = None,
-                 unwrap_inverse: bool = False) -> None:
+    def __init__(
+        self,
+        angle_features: Optional[np.ndarray] = None,
+        unwrap_inverse: bool = False,
+    ) -> None:
         """Instantiate :class:`AnglePreprocessor`.
 
         Parameters
         ----------
-        angle_features : np.ndarray
+        angle_features : Optional[np.ndarray]
             Indices of features that are angles.
         unwrap_inverse : bool
             Unwrap inverse by replacing absolute jumps greater than ``pi`` by
@@ -142,7 +144,7 @@ class AnglePreprocessor(koopman_pipeline.EpisodeIndependentLiftingFn):
     def _transform_feature_names(
         self,
         feature_names: np.ndarray,
-        format: str = None,
+        format: Optional[str] = None,
     ) -> np.ndarray:
         # noqa: D102
         if format == 'latex':
@@ -185,7 +187,7 @@ def random_state(low, high, rng=None):
         Lower bound for uniform random distribution.
     high : float or (n, 1) np.ndarray
         Upper bound for uniform random distribution.
-    rng : Generator
+    rng : Optional[Generator]
         Random number generator, `numpy.random.default_rng(seed)`.
 
     Returns
@@ -207,14 +209,16 @@ def random_state(low, high, rng=None):
     return x_rand
 
 
-def random_input(t_range,
-                 t_step,
-                 low,
-                 high,
-                 cutoff,
-                 order=2,
-                 rng=None,
-                 output='function'):
+def random_input(
+    t_range,
+    t_step,
+    low,
+    high,
+    cutoff,
+    order=2,
+    rng=None,
+    output='function',
+):
     """Generate a smooth random input.
 
     Generates uniform random data between specified bounds, lowpass filters the

--- a/pykoop/util.py
+++ b/pykoop/util.py
@@ -447,7 +447,7 @@ def example_data_pendulum() -> Dict[str, Any]:
             t_range=t_range,
             t_step=t_step,
             x0=x0,
-            u=lambda t: 0,
+            u=lambda t: np.array(0),
         )
         # Format the data
         X_pend_lst.append(np.hstack((

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,6 @@ pytest
 pytest-regressions
 sphinx
 sphinx-rtd-theme
+types-Deprecated
 
 mosek>=9.2.49

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -201,7 +201,7 @@ class TestDataRegressorExact:
         (
             pykoop.EdmdMeta(
                 regressor=sklearn.linear_model.OrthogonalMatchingPursuit(
-                    n_nonzero_coefs=2, normalize=False)),
+                    n_nonzero_coefs=2)),
             'mass_spring_damper_sine_input',
         ),
     ],


### PR DESCRIPTION
Resolves #141 

# Proposed Changes

- Update MyPy typing, which now requires `Optional` when `None` is used as a default argument.

# Checklist

- [x] Write unit tests
- [x] Add new estimators to existing `scikit-learn` compatibility tests
- [x] Write examples in docstrings
- [x] Update Sphinx documentation
- [x] Bump version number and date in `setup.py`, `CITATION.cff`, and
      `README.rst`
