### PR TITLE
Fix performance issues in `pykoop.predict_trajectory()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,6 +288,7 @@ dmypy.json
 
 # profiling data
 .prof
+*.prof
 
 ### Vim ###
 # Swap

--- a/benchmarks/benchmark_predict_trajectory.py
+++ b/benchmarks/benchmark_predict_trajectory.py
@@ -10,7 +10,6 @@ import pykoop
 
 def main():
     """Benchmark :func:`pykoop.predict_trajectory()`."""
-
     pykoop.set_config(skip_validation=True)
 
     # Get example mass-spring-damper data

--- a/benchmarks/benchmark_predict_trajectory.py
+++ b/benchmarks/benchmark_predict_trajectory.py
@@ -10,6 +10,9 @@ import pykoop
 
 def main():
     """Benchmark :func:`pykoop.predict_trajectory()`."""
+
+    pykoop.set_config(skip_validation=True)
+
     # Get example mass-spring-damper data
     eg = pykoop.example_data_pendulum()
     # Create pipeline

--- a/benchmarks/benchmark_predict_trajectory.py
+++ b/benchmarks/benchmark_predict_trajectory.py
@@ -1,0 +1,36 @@
+"""Benchmark :func:`pykoop.predict_trajectory()`.
+
+Outputs a ``.prof`` file that can be visualized using ``snakeviz``.
+"""
+
+import cProfile
+
+import pykoop
+
+
+def main():
+    """Benchmark :func:`pykoop.predict_trajectory()`."""
+    # Get example mass-spring-damper data
+    eg = pykoop.example_data_pendulum()
+    # Create pipeline
+    kp = pykoop.KoopmanPipeline(
+        lifting_functions=[
+            ('pl', pykoop.PolynomialLiftingFn(order=2)),
+            ('dl', pykoop.DelayLiftingFn(n_delays_state=2, n_delays_input=2)),
+        ],
+        regressor=pykoop.Edmd(alpha=1),
+    )
+    # Fit the pipeline
+    kp.fit(
+        eg['X_train'],
+        n_inputs=eg['n_inputs'],
+        episode_feature=eg['episode_feature'],
+    )
+    # Predict using the pipeline
+    with cProfile.Profile() as pr:
+        X_pred = kp.predict_trajectory(eg['X_train'])
+        pr.dump_stats('benchmark_predict_trajectory.prof')
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/benchmark_unique_episodes.py
+++ b/benchmarks/benchmark_unique_episodes.py
@@ -14,7 +14,7 @@ from pykoop.koopman_pipeline import _unique_episodes
 
 def main():
     """Benchmark :func:`pykoop.koopman_pipeline._unique_episodes()`."""
-    X_ep = np.array([0] * 100 + [1] * 1000 + [2] * 500 + [3] * 1000)
+    X_ep = np.array([0] * 100 + [1] * 1000 + [2] * 500 + [10] * 1000)
     n_loop = 100_000
     time = timeit.timeit(lambda: _unique_episodes(X_ep), number=n_loop)
     print(f'   Total time: {time} s')

--- a/benchmarks/benchmark_unique_episodes.py
+++ b/benchmarks/benchmark_unique_episodes.py
@@ -1,0 +1,20 @@
+"""Benchmark :func:`pykoop.koopman_pipeline._unique_episodes()`."""
+
+import timeit
+
+import numpy as np
+
+from pykoop.koopman_pipeline import _unique_episodes
+
+
+def main():
+    """Benchmark :func:`pykoop.koopman_pipeline._unique_episodes()`."""
+    X_ep = np.array([0] * 100 + [1] * 1000 + [2] * 500 + [3] * 1000)
+    n_loop = 100_000
+    time = timeit.timeit(lambda: _unique_episodes(X_ep), number=n_loop)
+    print(f'   Total time: {time} s')
+    print(f'Time per loop: {time / n_loop} s')
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/benchmark_unique_episodes.py
+++ b/benchmarks/benchmark_unique_episodes.py
@@ -1,4 +1,9 @@
-"""Benchmark :func:`pykoop.koopman_pipeline._unique_episodes()`."""
+"""Benchmark :func:`pykoop.koopman_pipeline._unique_episodes()`.
+
+It's very hard to do better than :func:`pandas.unique`, so I will stop messing
+with it. Another approach could be to store the unique episodes somewhere for
+reuse, but that could be convoluted.
+"""
 
 import timeit
 

--- a/benchmarks/benchmark_unique_episodes.py
+++ b/benchmarks/benchmark_unique_episodes.py
@@ -9,14 +9,16 @@ import timeit
 
 import numpy as np
 
-from pykoop.koopman_pipeline import _unique_episodes
+import pykoop
 
 
 def main():
     """Benchmark :func:`pykoop.koopman_pipeline._unique_episodes()`."""
+    pykoop.set_config(skip_validation=True)
+    """Benchmark :func:`pykoop.unique_episodes()`."""
     X_ep = np.array([0] * 100 + [1] * 1000 + [2] * 500 + [10] * 1000)
     n_loop = 100_000
-    time = timeit.timeit(lambda: _unique_episodes(X_ep), number=n_loop)
+    time = timeit.timeit(lambda: pykoop.unique_episodes(X_ep), number=n_loop)
     print(f'   Total time: {time} s')
     print(f'Time per loop: {time / n_loop} s')
 

--- a/doc/pykoop.rst
+++ b/doc/pykoop.rst
@@ -26,7 +26,8 @@ The data matrices provided to :func:`fit` (as well as :func:`transform`
 and :func:`inverse_transform`) must obey the following format:
 
 1. If ``episode_feature`` is true, the first feature must indicate
-   which episode each timestep belongs to.
+   which episode each timestep belongs to. The episode feature must contain
+   positive integers only.
 2. The last ``n_inputs`` features must be exogenous inputs.
 3. The remaining features are considered to be states (input-independent).
 
@@ -83,6 +84,9 @@ State 0 State 1 State 2
 
 In the above case, each timestep is assumed to belong to the same
 episode.
+
+.. important::
+   The episode feature must contain positive integers only!
 
 Koopman regressors, which implement the interface defined in
 :class:`pykoop.KoopmanRegressor` are distinct from ``scikit-learn`` regressors

--- a/doc/pykoop.rst
+++ b/doc/pykoop.rst
@@ -272,6 +272,20 @@ The following class and function implementations are located in
    pykoop.dynamic_models.Pendulum
 
 
+Configuration
+=============
+
+The following functions allow the user to interact with ``pykoop``'s global
+configuration.
+
+.. autosummary::
+   :toctree: _autosummary/
+
+   pykoop.get_config
+   pykoop.set_config
+   pykoop.config_context
+
+
 Extending ``pykoop``
 ====================
 

--- a/pykoop/__init__.py
+++ b/pykoop/__init__.py
@@ -1,5 +1,6 @@
 """Koopman operator identification library in Python."""
 
+from ._sklearn_config.config import config_context, get_config, set_config
 from .centers import (
     Centers,
     ClusterCenters,
@@ -10,7 +11,6 @@ from .centers import (
     QmcCenters,
     UniformRandomCenters,
 )
-from ._sklearn_config.config import config_context, get_config, set_config
 from .kernel_approximation import (
     KernelApproximation,
     RandomBinningKernelApprox,
@@ -30,6 +30,7 @@ from .koopman_pipeline import (
     shift_episodes,
     split_episodes,
     strip_initial_conditions,
+    unique_episodes,
 )
 from .lifting_functions import (
     BilinearInputLiftingFn,

--- a/pykoop/__init__.py
+++ b/pykoop/__init__.py
@@ -10,6 +10,7 @@ from .centers import (
     QmcCenters,
     UniformRandomCenters,
 )
+from ._sklearn_config.config import config_context, get_config, set_config
 from .kernel_approximation import (
     KernelApproximation,
     RandomBinningKernelApprox,
@@ -34,12 +35,12 @@ from .lifting_functions import (
     BilinearInputLiftingFn,
     ConstantLiftingFn,
     DelayLiftingFn,
+    KernelApproxLiftingFn,
     PolynomialLiftingFn,
     RbfLiftingFn,
-    KernelApproxLiftingFn,
     SkLearnLiftingFn,
 )
-from .regressors import Dmd, Dmdc, Edmd, EdmdMeta, DataRegressor
+from .regressors import DataRegressor, Dmd, Dmdc, Edmd, EdmdMeta
 from .tsvd import Tsvd
 from .util import (
     AnglePreprocessor,

--- a/pykoop/_sklearn_config/LICENSE
+++ b/pykoop/_sklearn_config/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2007-2022 The scikit-learn developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pykoop/_sklearn_config/config.py
+++ b/pykoop/_sklearn_config/config.py
@@ -1,0 +1,99 @@
+"""Global configuration for ``pykoop``.
+
+Based on code from the ``scikit-learn`` project. Original author of the file
+is Joel Nothman. Specifically, the original file is
+``scikit-learn/sklearn/_config.py`` from commit ``894b335``.
+
+Distributed under the BSD-3-Clause License. See ``LICENSE`` in this directory
+for the full license.
+"""
+
+import contextlib
+import os
+import threading
+from typing import Any, Dict, Optional
+
+_global_config = {
+    'skip_validation': False,
+}
+_threadlocal = threading.local()
+
+
+def _get_threadlocal_config() -> Dict[str, Any]:
+    """Get a threadlocal mutable configuration.
+
+    If the configuration does not exist, copy the default global configuration.
+    """
+    if not hasattr(_threadlocal, 'global_config'):
+        _threadlocal.global_config = _global_config.copy()
+    return _threadlocal.global_config
+
+
+def get_config() -> Dict[str, Any]:
+    """Retrieve current values for configuration set by :func:`set_config`.
+
+    Returns
+    -------
+    config : dict
+        Keys are parameter names that can be passed to :func:`set_config`.
+
+    Examples
+    --------
+    Get configuation
+
+    >>> pykoop.get_config()
+    {'skip_validation': False}
+    """
+    # Return a copy of the threadlocal configuration so that users will
+    # not be able to modify the configuration with the returned dict.
+    return _get_threadlocal_config().copy()
+
+
+def set_config(skip_validation: Optional[bool] = None) -> None:
+    """Set global configuration.
+
+    Parameters
+    ----------
+    skip_validation : Optional[bool]
+        Set to ``True`` to skip all parameter validation. Can save significant
+        time, especially in func:`pykoop.predict_trajectory()` but risks
+        crashes.
+
+    Examples
+    --------
+    Set configuation
+
+    >>> pykoop.set_config(skip_validation=False)
+    """
+    local_config = _get_threadlocal_config()
+    # Set parameters
+    if skip_validation is not None:
+        local_config['skip_validation'] = skip_validation
+
+
+@contextlib.contextmanager
+def config_context(*, skip_validation=None):
+    """Context manager for global configuration.
+
+    Parameters
+    ----------
+    skip_validation : Optional[bool]
+        Set to ``True`` to skip all parameter validation. Can save significant
+        time, especially in func:`pykoop.predict_trajectory()` but risks
+        crashes.
+
+    Examples
+    --------
+    Use config context manager
+
+    >>> with pykoop.config_context(skip_validation=False):
+    ...     pykoop.KoopmanPipeline()
+    KoopmanPipeline()
+    """
+    old_config = get_config()
+    set_config(skip_validation=skip_validation)
+
+    try:
+        yield
+    finally:
+        set_config(**old_config)

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -3678,13 +3678,13 @@ def split_episodes(
     if episode_feature:
         X_ep = X[:, 0]
         X = X[:, 1:]
+        # Split X into list of episodes. Each episode is a tuple containing
+        # its index and its associated data matrix.
+        episodes = []
+        for i in _unique_episodes(X_ep):
+            episodes.append((i, X[X_ep == i, :]))
     else:
-        X_ep = np.zeros((X.shape[0], ))
-    # Split X into list of episodes. Each episode is a tuple containing
-    # its index and its associated data matrix.
-    episodes = []
-    for i in _unique_episodes(X_ep):
-        episodes.append((i, X[X_ep == i, :]))
+        episodes = [(0, X)]
     # Return list of episodes
     return episodes
 

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -3716,7 +3716,7 @@ def split_episodes(
         # Split X into list of episodes. Each episode is a tuple containing
         # its index and its associated data matrix.
         episodes = []
-        for i in _unique_episodes(X_ep):
+        for i in unique_episodes(X_ep):
             episodes.append((i, X[X_ep == i, :]))
     else:
         episodes = [(0, X)]
@@ -3752,6 +3752,31 @@ def combine_episodes(episodes: List[Tuple[float, np.ndarray]],
     # Concatenate the combined episodes
     Xc = np.vstack(combined_episodes)
     return Xc
+
+
+def unique_episodes(X_ep: np.ndarray) -> np.ndarray:
+    """Find all the unique episodes in an episode feature array.
+
+    Parameters
+    ----------
+    X_ep : np.ndarray
+        Episode feature (as would be passed to :func:`KoopmanPipeine.fit()`).
+
+    Returns
+    -------
+    np.ndarray
+        List of unique episode indices.
+
+    Raises
+    ------
+    ValueError
+        If episode feature contains negative or fractional numbers.
+    """
+    if not config.get_config()['skip_validation']:
+        if np.any((X_ep % 1) != 0) or np.any(X_ep < 0):
+            raise ValueError(
+                'Episode feature must contain only positive whole numbers.')
+    return np.flatnonzero(np.bincount(X_ep.astype(int)))
 
 
 def _weights_from_data_matrix(
@@ -3838,21 +3863,3 @@ def _extract_feature_names(
         return np.asarray(X.columns, dtype=object)
     else:
         return None
-
-
-def _unique_episodes(X_ep: np.ndarray) -> List[float]:
-    """Find all the unique episodes in an episode feature array.
-
-    Parameters
-    ----------
-    X_ep : np.ndarray
-        Episode feature (as would be passed to :func:`KoopmanPipeine.fit()`).
-
-    Returns
-    -------
-    List[float]
-        List of unique episode indices.
-    """
-    # ``pandas.unique`` is faster than ``np.unique`` and preserves order.
-    episodes = list(pandas.unique(X_ep))
-    return episodes

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -14,6 +14,7 @@ from deprecated import deprecated
 from matplotlib import pyplot as plt
 from scipy import linalg
 
+from ._sklearn_config import config
 from ._sklearn_metaestimators import metaestimators
 
 # Create logger
@@ -742,32 +743,40 @@ class EpisodeIndependentLiftingFn(KoopmanLiftingFn):
 
     def transform(self, X: np.ndarray) -> np.ndarray:
         # noqa: D102
-        # Ensure fit has been done
-        sklearn.utils.validation.check_is_fitted(self)
-        # Check feature names
-        self._validate_feature_names(X)
-        # Validate data
-        X = sklearn.utils.validation.check_array(X, **self._check_array_params)
-        # Check input shape
-        if X.shape[1] != self.n_features_in_:
-            raise ValueError(f'{self.__class__.__name__} `fit()` called '
-                             f'with {self.n_features_in_} features, but '
-                             f'`transform()` called with {X.shape[1]} '
-                             'features.')
+        if not config.get_config()['skip_validation']:
+            # Ensure fit has been done
+            sklearn.utils.validation.check_is_fitted(self)
+            # Check feature names
+            self._validate_feature_names(X)
+            # Validate data
+            X = sklearn.utils.validation.check_array(
+                X,
+                **self._check_array_params,
+            )
+            # Check input shape
+            if X.shape[1] != self.n_features_in_:
+                raise ValueError(f'{self.__class__.__name__} `fit()` called '
+                                 f'with {self.n_features_in_} features, but '
+                                 f'`transform()` called with {X.shape[1]} '
+                                 'features.')
         return self._apply_transform_or_inverse(X, 'transform')
 
     def inverse_transform(self, X: np.ndarray) -> np.ndarray:
         # noqa: D102
-        # Ensure fit has been done
-        sklearn.utils.validation.check_is_fitted(self)
-        # Validate data
-        X = sklearn.utils.validation.check_array(X, **self._check_array_params)
-        # Check input shape
-        if X.shape[1] != self.n_features_out_:
-            raise ValueError(f'{self.__class__.__name__} `fit()` output '
-                             f'{self.n_features_out_} features, but '
-                             '`inverse_transform()` called with '
-                             f'{X.shape[1]} features.')
+        if not config.get_config()['skip_validation']:
+            # Ensure fit has been done
+            sklearn.utils.validation.check_is_fitted(self)
+            # Validate data
+            X = sklearn.utils.validation.check_array(
+                X,
+                **self._check_array_params,
+            )
+            # Check input shape
+            if X.shape[1] != self.n_features_out_:
+                raise ValueError(f'{self.__class__.__name__} `fit()` output '
+                                 f'{self.n_features_out_} features, but '
+                                 '`inverse_transform()` called with '
+                                 f'{X.shape[1]} features.')
         return self._apply_transform_or_inverse(X, 'inverse_transform')
 
     def n_samples_in(self, n_samples_out: int = 1) -> int:
@@ -979,32 +988,40 @@ class EpisodeDependentLiftingFn(KoopmanLiftingFn):
 
     def transform(self, X: np.ndarray) -> np.ndarray:
         # noqa: D102
-        # Ensure fit has been done
-        sklearn.utils.validation.check_is_fitted(self)
-        # Check feature names
-        self._validate_feature_names(X)
-        # Validate data
-        X = sklearn.utils.validation.check_array(X, **self._check_array_params)
-        # Check input shape
-        if X.shape[1] != self.n_features_in_:
-            raise ValueError(f'{self.__class__.__name__} `fit()` called '
-                             f'with {self.n_features_in_} features, but '
-                             f'`transform()` called with {X.shape[1]} '
-                             'features.')
+        if not config.get_config()['skip_validation']:
+            # Ensure fit has been done
+            sklearn.utils.validation.check_is_fitted(self)
+            # Check feature names
+            self._validate_feature_names(X)
+            # Validate data
+            X = sklearn.utils.validation.check_array(
+                X,
+                **self._check_array_params,
+            )
+            # Check input shape
+            if X.shape[1] != self.n_features_in_:
+                raise ValueError(f'{self.__class__.__name__} `fit()` called '
+                                 f'with {self.n_features_in_} features, but '
+                                 f'`transform()` called with {X.shape[1]} '
+                                 'features.')
         return self._apply_transform_or_inverse(X, 'transform')
 
     def inverse_transform(self, X: np.ndarray) -> np.ndarray:
         # noqa: D102
-        # Ensure fit has been done
-        sklearn.utils.validation.check_is_fitted(self)
-        # Validate data
-        X = sklearn.utils.validation.check_array(X, **self._check_array_params)
-        # Check input shape
-        if X.shape[1] != self.n_features_out_:
-            raise ValueError(f'{self.__class__.__name__} `fit()` output '
-                             f'{self.n_features_out_} features, but '
-                             '`inverse_transform()` called with '
-                             f'{X.shape[1]} features.')
+        if not config.get_config()['skip_validation']:
+            # Ensure fit has been done
+            sklearn.utils.validation.check_is_fitted(self)
+            # Validate data
+            X = sklearn.utils.validation.check_array(
+                X,
+                **self._check_array_params,
+            )
+            # Check input shape
+            if X.shape[1] != self.n_features_out_:
+                raise ValueError(f'{self.__class__.__name__} `fit()` output '
+                                 f'{self.n_features_out_} features, but '
+                                 '`inverse_transform()` called with '
+                                 f'{X.shape[1]} features.')
         return self._apply_transform_or_inverse(X, 'inverse_transform')
 
     def _apply_transform_or_inverse(self, X: np.ndarray,
@@ -1784,18 +1801,22 @@ class SplitPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
 
     def transform(self, X: np.ndarray) -> np.ndarray:
         # noqa: D102
-        # Check if fitted
-        sklearn.utils.validation.check_is_fitted(self)
-        # Check feature names
-        self._validate_feature_names(X)
-        # Validate input array
-        X = sklearn.utils.validation.check_array(X, **self._check_array_params)
-        # Check input shape
-        if X.shape[1] != self.n_features_in_:
-            raise ValueError(f'{self.__class__.__name__} `fit()` called '
-                             f'with {self.n_features_in_} features, but '
-                             f'`transform()` called with {X.shape[1]} '
-                             'features.')
+        if not config.get_config()['skip_validation']:
+            # Check if fitted
+            sklearn.utils.validation.check_is_fitted(self)
+            # Check feature names
+            self._validate_feature_names(X)
+            # Validate input array
+            X = sklearn.utils.validation.check_array(
+                X,
+                **self._check_array_params,
+            )
+            # Check input shape
+            if X.shape[1] != self.n_features_in_:
+                raise ValueError(f'{self.__class__.__name__} `fit()` called '
+                                 f'with {self.n_features_in_} features, but '
+                                 f'`transform()` called with {X.shape[1]} '
+                                 'features.')
         # Split episodes
         episodes = split_episodes(X, episode_feature=self.episode_feature_)
         episodes_state = []
@@ -1847,14 +1868,16 @@ class SplitPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
 
     def inverse_transform(self, X: np.ndarray) -> np.ndarray:
         # noqa: D102
-        sklearn.utils.validation.check_is_fitted(self)
-        X = sklearn.utils.validation.check_array(X, **self._check_array_params)
-        # Check input shape
-        if X.shape[1] != self.n_features_out_:
-            raise ValueError(f'{self.__class__.__name__} `fit()` output '
-                             f'{self.n_features_out_} features, but '
-                             '`inverse_transform()` called with '
-                             f'{X.shape[1]} features.')
+        if not config.get_config()['skip_validation']:
+            sklearn.utils.validation.check_is_fitted(self)
+            X = sklearn.utils.validation.check_array(
+                X, **self._check_array_params)
+            # Check input shape
+            if X.shape[1] != self.n_features_out_:
+                raise ValueError(f'{self.__class__.__name__} `fit()` output '
+                                 f'{self.n_features_out_} features, but '
+                                 '`inverse_transform()` called with '
+                                 f'{X.shape[1]} features.')
         # Split episodes
         episodes = split_episodes(X, episode_feature=self.episode_feature_)
         episodes_state = []
@@ -2244,18 +2267,22 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         np.ndarray
             Transformed data matrix.
         """
-        # Check if fitted
-        sklearn.utils.validation.check_is_fitted(self, 'transformers_fit_')
-        # Check feature names
-        self._validate_feature_names(X)
-        # Validate input array
-        X = sklearn.utils.validation.check_array(X, **self._check_array_params)
-        # Check input shape
-        if X.shape[1] != self.n_features_in_:
-            raise ValueError(f'{self.__class__.__name__} `fit()` called '
-                             f'with {self.n_features_in_} features, but '
-                             f'`transform()` called with {X.shape[1]} '
-                             'features.')
+        if not config.get_config()['skip_validation']:
+            # Check if fitted
+            sklearn.utils.validation.check_is_fitted(self, 'transformers_fit_')
+            # Check feature names
+            self._validate_feature_names(X)
+            # Validate input array
+            X = sklearn.utils.validation.check_array(
+                X,
+                **self._check_array_params,
+            )
+            # Check input shape
+            if X.shape[1] != self.n_features_in_:
+                raise ValueError(f'{self.__class__.__name__} `fit()` called '
+                                 f'with {self.n_features_in_} features, but '
+                                 f'`transform()` called with {X.shape[1]} '
+                                 'features.')
         # Apply lifting functions
         X_out = X
         for _, lf in self.lifting_functions_:
@@ -2275,14 +2302,18 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         np.ndarray
             Inverted transformed data matrix.
         """
-        sklearn.utils.validation.check_is_fitted(self, 'transformers_fit_')
-        X = sklearn.utils.validation.check_array(X, **self._check_array_params)
-        # Check input shape
-        if X.shape[1] != self.n_features_out_:
-            raise ValueError(f'{self.__class__.__name__} `fit()` output '
-                             f'{self.n_features_out_} features, but '
-                             '`inverse_transform()` called with '
-                             f'{X.shape[1]} features.')
+        if not config.get_config()['skip_validation']:
+            sklearn.utils.validation.check_is_fitted(self, 'transformers_fit_')
+            X = sklearn.utils.validation.check_array(
+                X,
+                **self._check_array_params,
+            )
+            # Check input shape
+            if X.shape[1] != self.n_features_out_:
+                raise ValueError(f'{self.__class__.__name__} `fit()` output '
+                                 f'{self.n_features_out_} features, but '
+                                 '`inverse_transform()` called with '
+                                 f'{X.shape[1]} features.')
         # Apply inverse lifting functions in reverse order
         X_out = X
         for _, lf in self.lifting_functions_[::-1]:
@@ -2318,12 +2349,16 @@ class KoopmanPipeline(metaestimators._BaseComposition, KoopmanLiftingFn):
         np.ndarray
             Predicted data matrix.
         """
-        # Check if fitted
-        sklearn.utils.validation.check_is_fitted(self, 'regressor_fit_')
-        # Check feature names
-        self._validate_feature_names(X)
-        # Validate input array
-        X = sklearn.utils.validation.check_array(X, **self._check_array_params)
+        if not config.get_config()['skip_validation']:
+            # Check if fitted
+            sklearn.utils.validation.check_is_fitted(self, 'regressor_fit_')
+            # Check feature names
+            self._validate_feature_names(X)
+            # Validate input array
+            X = sklearn.utils.validation.check_array(
+                X,
+                **self._check_array_params,
+            )
         # Lift data matrix
         X_trans = self.transform(X)
         # Predict in lifted space

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -3683,8 +3683,7 @@ def split_episodes(
     # Split X into list of episodes. Each episode is a tuple containing
     # its index and its associated data matrix.
     episodes = []
-    # ``pandas.unique`` is faster than ``np.unique`` and preserves order.
-    for i in pandas.unique(X_ep):
+    for i in _unique_episodes(X_ep):
         episodes.append((i, X[X_ep == i, :]))
     # Return list of episodes
     return episodes
@@ -3804,3 +3803,21 @@ def _extract_feature_names(
         return np.asarray(X.columns, dtype=object)
     else:
         return None
+
+
+def _unique_episodes(X_ep: np.ndarray) -> List[float]:
+    """Find all the unique episodes in an episode feature array.
+
+    Parameters
+    ----------
+    X_ep : np.ndarray
+        Episode feature (as would be passed to :func:`KoopmanPipeine.fit()`).
+
+    Returns
+    -------
+    List[float]
+        List of unique episode indices.
+    """
+    # ``pandas.unique`` is faster than ``np.unique`` and preserves order.
+    episodes = list(pandas.unique(X_ep))
+    return episodes

--- a/pykoop/lifting_functions.py
+++ b/pykoop/lifting_functions.py
@@ -7,6 +7,7 @@ defined in :class:`KoopmanLiftingFn`.
 from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
+import sklearn
 import sklearn.base
 import sklearn.kernel_approximation
 import sklearn.preprocessing
@@ -14,6 +15,8 @@ import sklearn.utils.validation
 from scipy import linalg
 
 from . import centers, kernel_approximation, koopman_pipeline
+
+from ._sklearn_config import config
 
 
 class SkLearnLiftingFn(koopman_pipeline.EpisodeIndependentLiftingFn):
@@ -249,7 +252,9 @@ class PolynomialLiftingFn(koopman_pipeline.EpisodeIndependentLiftingFn):
 
     def _transform_one_ep(self, X: np.ndarray) -> np.ndarray:
         # Transform states
-        Xt = self.transformer_.transform(X)
+        skip_validation = config.get_config()['skip_validation']
+        with sklearn.config_context(assume_finite=skip_validation):
+            Xt = self.transformer_.transform(X)
         # Reorder states
         return Xt[:, self.transform_order_]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,6 @@ pytest-regressions
 sphinx
 sphinx-rtd-theme
 types-Deprecated
+snakeviz
 
 mosek>=9.2.49

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,5 @@ sphinx
 sphinx-rtd-theme
 types-Deprecated
 snakeviz
-timeit
 
 mosek>=9.2.49

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,6 @@ sphinx
 sphinx-rtd-theme
 types-Deprecated
 snakeviz
+timeit
 
 mosek>=9.2.49

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,12 @@ setuptools.setup(
         'PyPI': 'https://pypi.org/project/pykoop/',
         'DOI': 'https://doi.org/10.5281/zenodo.5576490',
     },
-    packages=setuptools.find_packages(exclude=('tests', 'examples', 'doc')),
+    packages=setuptools.find_packages(exclude=(
+        'tests',
+        'examples',
+        'doc',
+        'benchmarks',
+    )),
     # Officially, Python 3.8 is the lowest supported version, but almost
     # everything works on Python 3.7.
     python_requires='>=3.7',

--- a/tests/test_koopman_pipeline.py
+++ b/tests/test_koopman_pipeline.py
@@ -1429,21 +1429,17 @@ class TestSplitCombineEpisodes:
     """Test :func:`split_episodes` and :func:`combine_episodes`."""
 
     def test_split_episodes(self, X, episodes, episode_feature):
-        """Test :func:`split_episodes`.
-
-        .. todo:: Break up multiple asserts.
-        """
-        # Split episodes
-        episodes_actual = pykoop.split_episodes(
-            X,
-            episode_feature=episode_feature,
-        )
-        # Compare every episode
-        for actual, expected in zip(episodes_actual, episodes):
-            i_actual, X_actual = actual
-            i_expected, X_expected = expected
-            assert i_actual == i_expected
-            np.testing.assert_allclose(X_actual, X_expected)
+        """Test :func:`split_episodes`."""
+        if episode_feature:
+            X_ep = X[:, 0]
+            X = X[:, 1:]
+            for i_exp, X_i_exp in episodes:
+                X_actual = X[X_ep == i_exp]
+                np.testing.assert_allclose(X_actual, X_i_exp)
+        else:
+            assert len(episodes) == 1
+            X_exp = episodes[0][1]
+            np.testing.assert_allclose(X, X_exp)
 
     def test_combine_episodes(self, X, episodes, episode_feature):
         """Test :func:`combine_episodes`."""


### PR DESCRIPTION
Resolves #150 

# Proposed Changes

- Add `pykoop.set_config()`, `pykoop.get_config()` and `pykoop.config_context()` to allow skipping validation in key areas.

# Checklist

- [x] Write unit tests
- [x] Add new estimators to existing `scikit-learn` compatibility tests
- [x] Write examples in docstrings
- [x] Update Sphinx documentation
- [x] Bump version number and date in `setup.py`, `CITATION.cff`, and
      `README.rst`
