### PR TITLE
Fix README typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,8 +173,8 @@ you can use
 .. code-block:: sh
 
    $ cd .git/hooks/
-   $ ln -s ../../.githooks/pre-commit.sh .
-   $ chmod +x ./pre-commit.sh
+   $ ln -s ../../.githooks/pre-commit .
+   $ chmod +x ./pre-commit
 
 You will need ``yapf`` installed for this.
 


### PR DESCRIPTION
Resolves #153 

# Proposed Changes

- Fix typo in githook setup instructions

# Checklist

- [x] Write unit tests
- [x] Add new estimators to existing `scikit-learn` compatibility tests
- [x] Write examples in docstrings
- [x] Update Sphinx documentation
- [x] Bump version number and date in `setup.py`, `CITATION.cff`, and
      `README.rst`
