### PR TITLE
Add Python 3.11 to CI unit tests

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{matrix.python-version}}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,6 @@ authors:
     orcid: "https://orcid.org/0000-0002-1987-9268"
     affiliation: "McGill University"
 title: "decargroup/pykoop"
-version: v1.1.4
+version: v1.2.0
 doi: 10.5281/zenodo.5576490
 url: "https://github.com/decargroup/pykoop"

--- a/README.rst
+++ b/README.rst
@@ -221,7 +221,7 @@ If you use this software in your research, please cite it as below or see
         url={https://github.com/decargroup/pykoop},
         publisher={Zenodo},
         author={Steven Dahdah and James Richard Forbes},
-        version = {{v1.1.4}},
+        version = {{v1.2.0}},
         year={2022},
     }
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst', 'r') as f:
 
 setuptools.setup(
     name='pykoop',
-    version='1.1.4',
+    version='1.2.0',
     description=('Koopman operator identification library in Python, '
                  'compatible with `scikit-learn`'),
     long_description=readme,


### PR DESCRIPTION
Resolves #155 

# Proposed Changes

- Add Python 311 to CI unit tests
- Bump version to 1.2.0

# Checklist

- [x] Write unit tests
- [x] Add new estimators to existing `scikit-learn` compatibility tests
- [x] Write examples in docstrings
- [x] Update Sphinx documentation
- [x] Bump version number and date in `setup.py`, `CITATION.cff`, and
      `README.rst`
