### PR TITLE
Dependencies are missing from Read the Docs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,3 +5,6 @@ build:
     python: "3.11"
 sphinx:
   configuration: doc/conf.py
+python:
+  install:
+    - requirements: requirements-dev.txt

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,6 @@ authors:
     orcid: "https://orcid.org/0000-0002-1987-9268"
     affiliation: "McGill University"
 title: "decargroup/pykoop"
-version: v1.2.2
+version: v1.2.3
 doi: 10.5281/zenodo.5576490
 url: "https://github.com/decargroup/pykoop"

--- a/README.rst
+++ b/README.rst
@@ -221,7 +221,7 @@ If you use this software in your research, please cite it as below or see
         url={https://github.com/decargroup/pykoop},
         publisher={Zenodo},
         author={Steven Dahdah and James Richard Forbes},
-        version = {{v1.2.2}},
+        version = {{v1.2.3}},
         year={2022},
     }
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst', 'r') as f:
 
 setuptools.setup(
     name='pykoop',
-    version='1.2.2',
+    version='1.2.3',
     description=('Koopman operator identification library in Python, '
                  'compatible with `scikit-learn`'),
     long_description=readme,


### PR DESCRIPTION
Resolves #162 

# Proposed Changes

- Add missing dependencies to `.readthedocs.yaml`

# Checklist

- [x] Write unit tests
- [x] Add new estimators to existing `scikit-learn` compatibility tests
- [x] Write examples in docstrings
- [x] Update Sphinx documentation
- [x] Bump version number and date in `setup.py`, `CITATION.cff`, and
      `README.rst`
