### PR TITLE
`pykoop` is slow to import

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,6 @@ authors:
     orcid: "https://orcid.org/0000-0002-1987-9268"
     affiliation: "McGill University"
 title: "decargroup/pykoop"
-version: v1.2.3
+version: v1.2.4
 doi: 10.5281/zenodo.5576490
 url: "https://github.com/decargroup/pykoop"

--- a/README.rst
+++ b/README.rst
@@ -221,7 +221,7 @@ If you use this software in your research, please cite it as below or see
         url={https://github.com/decargroup/pykoop},
         publisher={Zenodo},
         author={Steven Dahdah and James Richard Forbes},
-        version = {{v1.2.3}},
+        version = {{v1.2.4}},
         year={2022},
     }
 

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -6,7 +6,6 @@ import warnings
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-import pandas
 import sklearn.base
 import sklearn.exceptions
 import sklearn.metrics
@@ -3834,14 +3833,13 @@ def _weights_from_data_matrix(
     return weights
 
 
-def _extract_feature_names(
-        X: Union[np.ndarray, pandas.DataFrame]) -> Optional[np.ndarray]:
+def _extract_feature_names(X: Any) -> Optional[np.ndarray]:
     """Extract feature names from input array.
 
     Parameters
     ----------
-    X : Union[np.ndarray, pandas.DataFrame]
-        Input array.
+    X : Any
+        Input array, either ``np.ndarray`` or ``pandas.DataFrame``.
 
     Returns
     -------
@@ -3853,7 +3851,9 @@ def _extract_feature_names(
     ValueError
         If feature names are not strings.
     """
-    if isinstance(X, pandas.DataFrame):
+    if isinstance(X, np.ndarray):
+        return None
+    else:
         for name in X.columns:
             if not isinstance(name, str):
                 log.warning(
@@ -3861,5 +3861,3 @@ def _extract_feature_names(
                     'v1.2 comes out this will be upgraded to an exception.')
                 return None
         return np.asarray(X.columns, dtype=object)
-    else:
-        return None

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -3854,10 +3854,15 @@ def _extract_feature_names(X: Any) -> Optional[np.ndarray]:
     if isinstance(X, np.ndarray):
         return None
     else:
-        for name in X.columns:
-            if not isinstance(name, str):
-                log.warning(
-                    'Feature names must all be strings. When ``scikit-learn`` '
-                    'v1.2 comes out this will be upgraded to an exception.')
-                return None
-        return np.asarray(X.columns, dtype=object)
+        try:
+            for name in X.columns:
+                if not isinstance(name, str):
+                    log.warning('Feature names must all be strings. When '
+                                '``scikit-learn`` v1.2 comes out this will be '
+                                'upgraded to an exception.')
+                    return None
+            return np.asarray(X.columns, dtype=object)
+        except AttributeError:
+            return None
+        except TypeError:
+            return None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 # Requirements to install ``pykoop``, run all unit tests, and generate docs
 -r requirements.txt
 
+pandas
 pytest
 pytest-regressions
 sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ numpy>=1.21.0
 scipy>=1.7.0
 scikit-learn>=1.0.0
 PICOS>=2.4.0
-pandas>=1.3.1
 optht>=0.2.0
 Deprecated>=1.2.13
 matplotlib>=3.5.1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst', 'r') as f:
 
 setuptools.setup(
     name='pykoop',
-    version='1.2.3',
+    version='1.2.4',
     description=('Koopman operator identification library in Python, '
                  'compatible with `scikit-learn`'),
     long_description=readme,


### PR DESCRIPTION
Resolves #166 

# Proposed Changes

- Remove `pandas` dependency to speed up import

# Checklist

- [x] Write unit tests
- [x] Add new estimators to existing `scikit-learn` compatibility tests
- [x] Write examples in docstrings
- [x] Update Sphinx documentation
- [x] Bump version number and date in `setup.py`, `CITATION.cff`, and
      `README.rst`
