### PR TITLE
Fix `sklearn` method resolution order

### DIFF
--- a/pykoop/kernel_approximation.py
+++ b/pykoop/kernel_approximation.py
@@ -16,8 +16,8 @@ log.addHandler(logging.NullHandler())
 
 
 class KernelApproximation(
-        sklearn.base.BaseEstimator,
         sklearn.base.TransformerMixin,
+        sklearn.base.BaseEstimator,
         metaclass=abc.ABCMeta,
 ):
     """Base class for all kernel approximations.

--- a/pykoop/koopman_pipeline.py
+++ b/pykoop/koopman_pipeline.py
@@ -22,8 +22,8 @@ log.addHandler(logging.NullHandler())
 
 
 class KoopmanLiftingFn(
-        sklearn.base.BaseEstimator,
         sklearn.base.TransformerMixin,
+        sklearn.base.BaseEstimator,
         metaclass=abc.ABCMeta,
 ):
     """Base class for Koopman lifting functions.
@@ -1138,9 +1138,11 @@ class EpisodeDependentLiftingFn(KoopmanLiftingFn):
         raise NotImplementedError()
 
 
-class KoopmanRegressor(sklearn.base.BaseEstimator,
-                       sklearn.base.RegressorMixin,
-                       metaclass=abc.ABCMeta):
+class KoopmanRegressor(
+        sklearn.base.RegressorMixin,
+        sklearn.base.BaseEstimator,
+        metaclass=abc.ABCMeta,
+):
     """Base class for Koopman regressors.
 
     All attributes with a trailing underscore are set by :func:`fit`.
@@ -1628,6 +1630,7 @@ class KoopmanRegressor(sklearn.base.BaseEstimator,
         return {
             'multioutput': True,
             'multioutput_only': True,
+            'requires_y': False,
         }
 
 

--- a/pykoop/lmi_regressors.py
+++ b/pykoop/lmi_regressors.py
@@ -103,6 +103,7 @@ class LmiRegressor(koopman_pipeline.KoopmanRegressor):
         return {
             'multioutput': True,
             'multioutput_only': True,
+            'requires_y': False,
             '_xfail_checks': {
                 'check_fit_idempotent': reason,
             }
@@ -2155,7 +2156,7 @@ class LmiEdmdDissipativityConstr(LmiRegressor):
         return problem_b
 
 
-class LmiHinfZpkMeta(sklearn.base.BaseEstimator, sklearn.base.RegressorMixin):
+class LmiHinfZpkMeta(sklearn.base.RegressorMixin, sklearn.base.BaseEstimator):
     """Meta-estimator where H-infinity weight is specified in ZPK format.
 
     H-infinity regularization weights must normally be specified in
@@ -2375,6 +2376,7 @@ class LmiHinfZpkMeta(sklearn.base.BaseEstimator, sklearn.base.RegressorMixin):
         return {
             'multioutput': True,
             'multioutput_only': True,
+            'requires_y': False,
         }
 
 

--- a/pykoop/regressors.py
+++ b/pykoop/regressors.py
@@ -402,6 +402,7 @@ class Dmd(koopman_pipeline.KoopmanRegressor):
         return {
             'multioutput': True,
             'multioutput_only': True,
+            'requires_y': False,
             '_xfail_checks': {
                 'check_estimators_dtypes': reason,
                 'check_fit_score_takes_y': reason,
@@ -504,6 +505,7 @@ class DataRegressor(koopman_pipeline.KoopmanRegressor):
         return {
             'multioutput': True,
             'multioutput_only': True,
+            'requires_y': False,
             # Allow a bad score since the ``coef_`` matrix will be filled with
             # zeros, and we just care to test ``scikit-learn`` API compliance.
             'poor_score': True,


### PR DESCRIPTION
Resolves #176 

# Proposed Changes

- Fix `scikit-learn` MRO based on https://scikit-learn.org/stable/developers/develop.html#rolling-your-own-estimator

# Checklist

- [x] Write unit tests
- [x] Add new estimators to existing `scikit-learn` compatibility tests
- [x] Write examples in docstrings
- [x] Update Sphinx documentation
- [x] Bump version number and date in `setup.py`, `CITATION.cff`, and
      `README.rst`
