### PR TITLE
Fix inverse Fourier transform naming

### DIFF
--- a/.github/workflows/test-package-no-mosek.yml
+++ b/.github/workflows/test-package-no-mosek.yml
@@ -1,4 +1,4 @@
-name: Test package
+name: Test package (no MOSEK)
 on:
   push:
     branches: [main]
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{matrix.python-version}}
@@ -23,4 +23,4 @@ jobs:
         python -m pip install -r requirements-dev.txt
     - name: Test with pytest
       run: |
-        pytest --exitfirst --remote
+        pytest --exitfirst -k "not mosek"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,6 @@ authors:
     orcid: "https://orcid.org/0000-0002-1987-9268"
     affiliation: "McGill University"
 title: "decargroup/pykoop"
-version: v1.2.4
+version: v2.0.0
 doi: 10.5281/zenodo.5576490
 url: "https://github.com/decargroup/pykoop"

--- a/README.rst
+++ b/README.rst
@@ -221,7 +221,7 @@ If you use this software in your research, please cite it as below or see
         url={https://github.com/decargroup/pykoop},
         publisher={Zenodo},
         author={Steven Dahdah and James Richard Forbes},
-        version = {{v1.2.4}},
+        version = {{v2.0.0}},
         year={2022},
     }
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst', 'r') as f:
 
 setuptools.setup(
     name='pykoop',
-    version='1.2.4',
+    version='2.0.0',
     description=('Koopman operator identification library in Python, '
                  'compatible with `scikit-learn`'),
     long_description=readme,

--- a/tests/test_kernel_approximation.py
+++ b/tests/test_kernel_approximation.py
@@ -11,7 +11,7 @@ import pykoop
 @pytest.mark.parametrize('est, kern, X', [
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='gaussian',
+            kernel_or_ft='gaussian',
             n_components=int(1e4),
             shape=1,
             method='weight_only',
@@ -25,7 +25,7 @@ import pykoop
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='gaussian',
+            kernel_or_ft='gaussian',
             n_components=int(1e4),
             shape=3,
             method='weight_only',
@@ -39,7 +39,7 @@ import pykoop
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='gaussian',
+            kernel_or_ft='gaussian',
             n_components=int(1e4),
             shape=1,
             method='weight_offset',
@@ -53,7 +53,7 @@ import pykoop
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='laplacian',
+            kernel_or_ft='laplacian',
             n_components=int(1e5),
             shape=1,
             method='weight_only',
@@ -67,7 +67,7 @@ import pykoop
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='laplacian',
+            kernel_or_ft='laplacian',
             n_components=int(1e5),
             shape=3,
             method='weight_only',
@@ -81,7 +81,7 @@ import pykoop
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='laplacian',
+            kernel_or_ft='laplacian',
             n_components=int(1e5),
             shape=1,
             method='weight_offset',
@@ -95,7 +95,7 @@ import pykoop
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='cauchy',
+            kernel_or_ft='cauchy',
             n_components=int(1e5),
             shape=1,
             method='weight_only',
@@ -109,7 +109,7 @@ import pykoop
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='cauchy',
+            kernel_or_ft='cauchy',
             n_components=int(1e5),
             shape=3,
             method='weight_only',
@@ -123,7 +123,7 @@ import pykoop
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='cauchy',
+            kernel_or_ft='cauchy',
             n_components=int(1e6),
             shape=1,
             method='weight_offset',
@@ -190,7 +190,7 @@ class TestKernelApproximation:
 @pytest.mark.parametrize('est, est_sk, X', [
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='gaussian',
+            kernel_or_ft='gaussian',
             n_components=int(1e4),
             shape=1,
             method='weight_only',
@@ -208,7 +208,7 @@ class TestKernelApproximation:
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='gaussian',
+            kernel_or_ft='gaussian',
             n_components=int(1e4),
             shape=1,
             method='weight_offset',
@@ -253,7 +253,7 @@ class TestKernelApproximationSklearn:
 @pytest.mark.parametrize('est, X', [
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='gaussian',
+            kernel_or_ft='gaussian',
             n_components=int(1e4),
             shape=1,
             method='weight_only',
@@ -266,7 +266,7 @@ class TestKernelApproximationSklearn:
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='gaussian',
+            kernel_or_ft='gaussian',
             n_components=int(1e4),
             shape=3,
             method='weight_only',
@@ -279,7 +279,7 @@ class TestKernelApproximationSklearn:
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='gaussian',
+            kernel_or_ft='gaussian',
             n_components=int(1e4),
             shape=1,
             method='weight_offset',
@@ -292,7 +292,7 @@ class TestKernelApproximationSklearn:
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='laplacian',
+            kernel_or_ft='laplacian',
             n_components=int(1e5),
             shape=1,
             method='weight_only',
@@ -305,7 +305,7 @@ class TestKernelApproximationSklearn:
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='laplacian',
+            kernel_or_ft='laplacian',
             n_components=int(1e5),
             shape=3,
             method='weight_only',
@@ -318,7 +318,7 @@ class TestKernelApproximationSklearn:
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='laplacian',
+            kernel_or_ft='laplacian',
             n_components=int(1e5),
             shape=1,
             method='weight_offset',
@@ -331,7 +331,7 @@ class TestKernelApproximationSklearn:
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='cauchy',
+            kernel_or_ft='cauchy',
             n_components=int(1e5),
             shape=1,
             method='weight_only',
@@ -344,7 +344,7 @@ class TestKernelApproximationSklearn:
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='cauchy',
+            kernel_or_ft='cauchy',
             n_components=int(1e5),
             shape=3,
             method='weight_only',
@@ -357,7 +357,7 @@ class TestKernelApproximationSklearn:
     ),
     (
         pykoop.RandomFourierKernelApprox(
-            kernel_or_ift='cauchy',
+            kernel_or_ft='cauchy',
             n_components=int(1e6),
             shape=1,
             method='weight_offset',

--- a/tests/test_koopman_pipeline.py
+++ b/tests/test_koopman_pipeline.py
@@ -1097,8 +1097,6 @@ class TestEpisodeManipulation:
         np.testing.assert_allclose(X1s, X2s)
 
 
-@pytest.mark.filterwarnings(
-    'ignore:Call to deprecated method predict_multistep')
 @pytest.mark.parametrize(
     'kp',
     [
@@ -1186,8 +1184,6 @@ class TestPredictionNoInput:
         np.testing.assert_allclose(X_sim, X_sim_exp)
 
 
-@pytest.mark.filterwarnings(
-    'ignore:Call to deprecated method predict_multistep')
 @pytest.mark.parametrize(
     'kp',
     [
@@ -1380,41 +1376,6 @@ class TestPrediction:
             },
             default_tolerance=dict(atol=1e-6, rtol=0),
         )
-
-    def test_predict_multistep(self, kp, mass_spring_damper_sine_input):
-        """Test :func:`predict_multistep` (deprecated)."""
-        msg = 'Test only works when there is no episode feature.'
-        assert (not mass_spring_damper_sine_input['episode_feature']), msg
-        # Extract initial conditions
-        x0 = pykoop.extract_initial_conditions(
-            mass_spring_damper_sine_input['X_train'],
-            kp.min_samples_,
-            n_inputs=mass_spring_damper_sine_input['n_inputs'],
-            episode_feature=mass_spring_damper_sine_input['episode_feature'],
-        )
-        # Extract input
-        u = pykoop.extract_input(
-            mass_spring_damper_sine_input['X_train'],
-            n_inputs=mass_spring_damper_sine_input['n_inputs'],
-            episode_feature=mass_spring_damper_sine_input['episode_feature'],
-        )
-        # Set up initial conditions and input
-        X_ic = np.zeros(mass_spring_damper_sine_input['X_train'].shape)
-        X_ic[:kp.min_samples_, :x0.shape[1]] = x0
-        X_ic[:, x0.shape[1]:] = u
-        # Predict using ``predict_multistep``
-        X_sim = kp.predict_multistep(X_ic)
-        # Predict manually
-        X_sim_exp = np.zeros(mass_spring_damper_sine_input['Xp_train'].shape)
-        X_sim_exp[:kp.min_samples_, :] = x0
-        for k in range(kp.min_samples_, u.shape[0]):
-            X = np.hstack((
-                X_sim_exp[(k - kp.min_samples_):k, :],
-                u[(k - kp.min_samples_):k, :],
-            ))
-            Xp = kp.predict(X)
-            X_sim_exp[[k], :] = Xp[[-1], :]
-        np.testing.assert_allclose(X_sim, X_sim_exp)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves #175

# Proposed Changes

- Rename `kernel_or_ift` to `kernel_or_ft`
- Split MOSEK and non-MOSEK tests
- Remove deprecated `predict_multistep()`

# Checklist

- [x] Write unit tests
- [x] Add new estimators to existing `scikit-learn` compatibility tests
- [x] Write examples in docstrings
- [x] Update Sphinx documentation
- [x] Bump version number and date in `setup.py`, `CITATION.cff`, and
      `README.rst`
