### PR TITLE
Fix int datatype

### DIFF
--- a/pykoop/kernel_approximation.py
+++ b/pykoop/kernel_approximation.py
@@ -479,6 +479,6 @@ class RandomBinningKernelApprox(KernelApproximation):
                 hash(tuple(coords[sample, :, component].astype(int)))
                 for component in range(coords.shape[2])
             ] for sample in range(coords.shape[0])],
-            dtype=int,
+            dtype=np.int64,
         )
         return coords_hashed


### PR DESCRIPTION
Resolves #183 

# Proposed Changes

- Change `int` to `np.int64` in `RandomBinningKernelApprox`.

# Checklist

- [x] Write unit tests
- [x] Add new estimators to existing `scikit-learn` compatibility tests
- [x] Write examples in docstrings
- [x] Update Sphinx documentation
- [x] Bump version number and date in `setup.py`, `CITATION.cff`, and
      `README.rst`
